### PR TITLE
Fix: Returning conjugation to base conjugation for all keyboard languages

### DIFF
--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -1271,6 +1271,12 @@ class KeyboardViewController: UIInputViewController {
       if getConjugation && commandState == true { // conjugate state
         // Reset to the most basic conjugations.
         deConjugationState = .indicativePresent
+        frConjugationState = .indicativePresent
+        ptConjugationState = .indicativePresent
+        esConjugationState = .indicativePresent
+        itConjugationState = .present
+        ruConjugationState = .present
+        svConjugationState = .active
         let triggerConjugationState = triggerConjugation(commandBar: commandBar)
         if triggerConjugationState == true {
           conjugateView = true


### PR DESCRIPTION
- PR for issue #168 
- Added required conjugation code references to [KeyboardsBase/KeyboardViewController.swift](https://github.com/scribe-org/Scribe-iOS/blob/main/Keyboards/KeyboardsBase/KeyboardViewController.swift) for all keyboard languages.