### PR TITLE
Assigning placeholder variables in all language keyboards

### DIFF
--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
@@ -47,14 +47,18 @@ let languagesWithCaseDependantOnPrepositions = ["German", "Russian"]
 // MARK: Translate Variables
 var translateKeyLbl: String = ""
 var translatePrompt: String = ""
+var translatePlaceholder: String = ""
 var translatePromptAndCursor: String = ""
+var translatePromptAndPlaceholder: String = ""
 var getTranslation: Bool = false
 var wordToTranslate: String = ""
 
 // MARK: Conjugate Variables
 var conjugateKeyLbl: String = ""
 var conjugatePrompt: String = ""
+var conjugatePlaceholder: String = ""
 var conjugatePromptAndCursor: String = ""
+var conjugatePromptAndPlaceholder: String = ""
 var getConjugation: Bool = false
 var conjugateView: Bool = false
 var conjugateAlternateView: Bool = false
@@ -94,7 +98,9 @@ var verbConjugated: String = ""
 // MARK: Plural Variables
 var pluralKeyLbl: String = ""
 var pluralPrompt: String = ""
+var pluralPlaceholder: String = ""
 var pluralPromptAndCursor: String = ""
+var pluralPromptAndPlaceholder: String = ""
 var getPlural: Bool = false
 var isAlreadyPluralState: Bool = false
 var isAlreadyPluralMessage: String = ""

--- a/Keyboards/LanguageKeyboards/French/FRInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FRInterfaceVariables.swift
@@ -109,15 +109,21 @@ func setFRKeyboardLayout() {
   invalidCommandMsg = "Pas dans Wikidata"
 
   translateKeyLbl = "Traduire"
+  translatePlaceholder = "Entrez le mot"
   translatePrompt = commandPromptSpacing + "fr -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
+  translatePromptAndPlaceholder = translatePromptAndCursor + translatePlaceholder
 
   conjugateKeyLbl = "Conjuguer"
+  conjugatePlaceholder = "Entrez le verbe"
   conjugatePrompt = commandPromptSpacing + "Conjuguer: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
+  conjugatePromptAndPlaceholder = conjugatePromptAndCursor + conjugatePlaceholder
 
   pluralKeyLbl = "Pluriel"
+  pluralPlaceholder = "Entrez le nom"
   pluralPrompt = commandPromptSpacing + "Pluriel: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
+  pluralPromptAndPlaceholder = pluralPromptAndCursor + pluralPlaceholder
   isAlreadyPluralMessage = "Déjà pluriel"
 }

--- a/Keyboards/LanguageKeyboards/French/FRInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FRInterfaceVariables.swift
@@ -109,19 +109,19 @@ func setFRKeyboardLayout() {
   invalidCommandMsg = "Pas dans Wikidata"
 
   translateKeyLbl = "Traduire"
-  translatePlaceholder = "Entrez le mot"
+  translatePlaceholder = "Entrez un mot"
   translatePrompt = commandPromptSpacing + "fr -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
   translatePromptAndPlaceholder = translatePromptAndCursor + translatePlaceholder
 
   conjugateKeyLbl = "Conjuguer"
-  conjugatePlaceholder = "Entrez le verbe"
+  conjugatePlaceholder = "Entrez un verbe"
   conjugatePrompt = commandPromptSpacing + "Conjuguer: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
   conjugatePromptAndPlaceholder = conjugatePromptAndCursor + conjugatePlaceholder
 
   pluralKeyLbl = "Pluriel"
-  pluralPlaceholder = "Entrez le nom"
+  pluralPlaceholder = "Entrez un nom"
   pluralPrompt = commandPromptSpacing + "Pluriel: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
   pluralPromptAndPlaceholder = pluralPromptAndCursor + pluralPlaceholder

--- a/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
@@ -115,15 +115,21 @@ func setDEKeyboardLayout() {
   invalidCommandMsg = "Nicht in Wikidata"
 
   translateKeyLbl = "Übersetzen"
+  translatePlaceholder = "Wort engeben"
   translatePrompt = commandPromptSpacing + "de -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
+  translatePromptAndPlaceholder = translatePromptAndCursor + translatePlaceholder
 
   conjugateKeyLbl = "Konjugieren"
+  conjugatePlaceholder = "Verb eingeben"
   conjugatePrompt = commandPromptSpacing + "Konjugieren: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
+  conjugatePromptAndPlaceholder = conjugatePromptAndCursor + conjugatePlaceholder
 
   pluralKeyLbl = "Plural"
+  pluralPlaceholder = "Nomen eingeben"
   pluralPrompt = commandPromptSpacing + "Plural: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
+  pluralPromptAndPlaceholder = pluralPromptAndCursor + pluralPlaceholder
   isAlreadyPluralMessage = "Schon Plural"
 }

--- a/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
@@ -109,19 +109,19 @@ func setITKeyboardLayout() {
   invalidCommandMsg = "Non in Wikidata"
 
   translateKeyLbl = "Tradurre"
-  translatePlaceholder = "Inserisci parola"
+  translatePlaceholder = "Inserisci una parola"
   translatePrompt = commandPromptSpacing + "it -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
   translatePromptAndPlaceholder = translatePromptAndCursor + translatePlaceholder
 
   conjugateKeyLbl = "Coniugare"
-  conjugatePlaceholder = "Inserisci il verbo"
+  conjugatePlaceholder = "Inserisci un verbo"
   conjugatePrompt = commandPromptSpacing + "Coniugare: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
   conjugatePromptAndPlaceholder = conjugatePromptAndCursor + conjugatePlaceholder
 
   pluralKeyLbl = "Plurale"
-  pluralPlaceholder = "Inserisci il nome"
+  pluralPlaceholder = "Inserisci un nome"
   pluralPrompt = commandPromptSpacing + "Plurale: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
   pluralPromptAndPlaceholder = pluralPromptAndCursor + pluralPlaceholder

--- a/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
@@ -109,15 +109,21 @@ func setITKeyboardLayout() {
   invalidCommandMsg = "Non in Wikidata"
 
   translateKeyLbl = "Tradurre"
+  translatePlaceholder = "Inserisci parola"
   translatePrompt = commandPromptSpacing + "it -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
+  translatePromptAndPlaceholder = translatePromptAndCursor + translatePlaceholder
 
   conjugateKeyLbl = "Coniugare"
+  conjugatePlaceholder = "Inserisci il verbo"
   conjugatePrompt = commandPromptSpacing + "Coniugare: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
+  conjugatePromptAndPlaceholder = conjugatePromptAndCursor + conjugatePlaceholder
 
   pluralKeyLbl = "Plurale"
+  pluralPlaceholder = "Inserisci il nome"
   pluralPrompt = commandPromptSpacing + "Plurale: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
+  pluralPromptAndPlaceholder = pluralPromptAndCursor + pluralPlaceholder
   isAlreadyPluralMessage = "Già plurale"
 }

--- a/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
@@ -107,19 +107,19 @@ func setPTKeyboardLayout() {
   invalidCommandMsg = "Não está no Wikidata"
 
   translateKeyLbl = "Traduzir"
-  translatePlaceholder = "Digite a palavra"
+  translatePlaceholder = "Digite uma palavra"
   translatePrompt = commandPromptSpacing + "pt -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
   translatePromptAndPlaceholder = translatePromptAndCursor + translatePlaceholder
 
   conjugateKeyLbl = "Conjugar"
-  conjugatePlaceholder = "Digite o verbo"
+  conjugatePlaceholder = "Digite um verbo"
   conjugatePrompt = commandPromptSpacing + "Conjugar: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
   conjugatePromptAndPlaceholder = conjugatePromptAndCursor + conjugatePlaceholder
 
   pluralKeyLbl = "Plural"
-  pluralPlaceholder = "Digite o substantivo"
+  pluralPlaceholder = "Digite um substantivo"
   pluralPrompt = commandPromptSpacing + "Plural: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
   pluralPromptAndPlaceholder = pluralPromptAndCursor + pluralPlaceholder

--- a/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
@@ -107,15 +107,21 @@ func setPTKeyboardLayout() {
   invalidCommandMsg = "Não está no Wikidata"
 
   translateKeyLbl = "Traduzir"
+  translatePlaceholder = "Digite a palavra"
   translatePrompt = commandPromptSpacing + "pt -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
+  translatePromptAndPlaceholder = translatePromptAndCursor + translatePlaceholder
 
   conjugateKeyLbl = "Conjugar"
+  conjugatePlaceholder = "Digite o verbo"
   conjugatePrompt = commandPromptSpacing + "Conjugar: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
+  conjugatePromptAndPlaceholder = conjugatePromptAndCursor + conjugatePlaceholder
 
   pluralKeyLbl = "Plural"
+  pluralPlaceholder = "Digite o substantivo"
   pluralPrompt = commandPromptSpacing + "Plural: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
+  pluralPromptAndPlaceholder = pluralPromptAndCursor + pluralPlaceholder
   isAlreadyPluralMessage = "Já plural"
 }

--- a/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
@@ -97,15 +97,21 @@ func setRUKeyboardLayout() {
   invalidCommandMsg = "Нет в Викиданных"
 
   translateKeyLbl = "Перевести"
+  translatePlaceholder = "Введите слово"
   translatePrompt = commandPromptSpacing + "ru -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
+  translatePromptAndPlaceholder = translatePromptAndCursor + translatePlaceholder
 
   conjugateKeyLbl = "Спрягать"
+  conjugatePlaceholder = "Введите глагол"
   conjugatePrompt = commandPromptSpacing + "Спрягать: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
+  conjugatePromptAndPlaceholder = conjugatePromptAndCursor + conjugatePlaceholder
 
   pluralKeyLbl = "Множ"
+  pluralPlaceholder = "Введите существительное"
   pluralPrompt = commandPromptSpacing + "Множ: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
+  pluralPromptAndPlaceholder = pluralPromptAndCursor + pluralPlaceholder
   isAlreadyPluralMessage = "Уже во множ"
 }

--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -111,15 +111,21 @@ func setESKeyboardLayout() {
   invalidCommandMsg = "No en Wikidata"
 
   translateKeyLbl = "Traducir"
+  translatePlaceholder = "Ingrese la palabra"
   translatePrompt = commandPromptSpacing + "es -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
+  translatePromptAndPlaceholder = translatePromptAndCursor + translatePlaceholder
 
   conjugateKeyLbl = "Conjugar"
+  conjugatePlaceholder = "Ingresar verbo"
   conjugatePrompt = commandPromptSpacing + "Conjugar: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
+  conjugatePromptAndPlaceholder = conjugatePromptAndCursor + conjugatePlaceholder
 
   pluralKeyLbl = "Plural"
+  pluralPlaceholder = "Ingrese sustantivo"
   pluralPrompt = commandPromptSpacing + "Plural: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
+  pluralPromptAndPlaceholder = pluralPromptAndCursor + pluralPlaceholder
   isAlreadyPluralMessage = "Ya en plural"
 }

--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -111,19 +111,19 @@ func setESKeyboardLayout() {
   invalidCommandMsg = "No en Wikidata"
 
   translateKeyLbl = "Traducir"
-  translatePlaceholder = "Ingrese la palabra"
+  translatePlaceholder = "Ingrese una palabra"
   translatePrompt = commandPromptSpacing + "es -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
   translatePromptAndPlaceholder = translatePromptAndCursor + translatePlaceholder
 
   conjugateKeyLbl = "Conjugar"
-  conjugatePlaceholder = "Ingresar verbo"
+  conjugatePlaceholder = "Ingresar un verbo"
   conjugatePrompt = commandPromptSpacing + "Conjugar: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
   conjugatePromptAndPlaceholder = conjugatePromptAndCursor + conjugatePlaceholder
 
   pluralKeyLbl = "Plural"
-  pluralPlaceholder = "Ingrese sustantivo"
+  pluralPlaceholder = "Ingrese un sustantivo"
   pluralPrompt = commandPromptSpacing + "Plural: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
   pluralPromptAndPlaceholder = pluralPromptAndCursor + pluralPlaceholder

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -113,19 +113,19 @@ func setSVKeyboardLayout() {
   invalidCommandMsg = "Inte i Wikidata"
 
   translateKeyLbl = "Översätt"
-  translatePlaceholder = "Skriv in ord"
+  translatePlaceholder = "Ange ett ord"
   translatePrompt = commandPromptSpacing + "sv -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
   translatePromptAndPlaceholder = translatePromptAndCursor + translatePlaceholder
 
   conjugateKeyLbl = "Konjugera"
-  conjugatePlaceholder = "Ange verb"
+  conjugatePlaceholder = "Ange ett verb"
   conjugatePrompt = commandPromptSpacing + "Konjugera: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
   conjugatePromptAndPlaceholder = conjugatePromptAndCursor + conjugatePlaceholder
 
   pluralKeyLbl = "Plural"
-  pluralPlaceholder = "Ange substantiv"
+  pluralPlaceholder = "Ange ett substantiv"
   pluralPrompt = commandPromptSpacing + "Plural: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
   pluralPromptAndPlaceholder = pluralPromptAndCursor + pluralPlaceholder

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -113,15 +113,21 @@ func setSVKeyboardLayout() {
   invalidCommandMsg = "Inte i Wikidata"
 
   translateKeyLbl = "Översätt"
+  translatePlaceholder = "Skriv in ord"
   translatePrompt = commandPromptSpacing + "sv -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
+  translatePromptAndPlaceholder = translatePromptAndCursor + translatePlaceholder
 
   conjugateKeyLbl = "Konjugera"
+  conjugatePlaceholder = "Ange verb"
   conjugatePrompt = commandPromptSpacing + "Konjugera: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
+  conjugatePromptAndPlaceholder = conjugatePromptAndCursor + conjugatePlaceholder
 
   pluralKeyLbl = "Plural"
+  pluralPlaceholder = "Ange substantiv"
   pluralPrompt = commandPromptSpacing + "Plural: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
+  pluralPromptAndPlaceholder = pluralPromptAndCursor + pluralPlaceholder
   isAlreadyPluralMessage = "Redan plural"
 }


### PR DESCRIPTION
- PR for first stage of issue #35 
- Added `translatePlaceholder`, `conjugatePlaceholder`, `pluralPlaceholder`, `translatePromptAndPlaceholder`, `conjugatePromptAndPlaceholder`, and `pluralPromptAndPlaceholder` to [CommandVariables.swift](https://github.com/scribe-org/Scribe-iOS/blob/47aa534852abeb76c28206a9030ddf2bacb616cd/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift)
- Assigned corresponding values using Google Translate for all the keyboard languages in respective files.

@andrewtavis please review these changes. Thank you 😊