### PR TITLE
Feat: Adding placeholder prompts to Command Bar

### DIFF
--- a/Keyboards/KeyboardsBase/InterfaceVariables.swift
+++ b/Keyboards/KeyboardsBase/InterfaceVariables.swift
@@ -118,7 +118,7 @@ func setKeyboardLayout() {
     setLayoutFxn()
   }
 
-  allPrompts = [translatePromptAndCursor, conjugatePromptAndCursor, pluralPromptAndCursor]
+  allPrompts = [translatePromptAndCursor, conjugatePromptAndCursor, pluralPromptAndCursor, translatePromptAndPlaceholder, conjugatePromptAndPlaceholder, pluralPromptAndPlaceholder]
 }
 
 // Variables that define which keys are positioned on the very left, right or in the center of the keyboard.

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -1091,7 +1091,7 @@ class KeyboardViewController: UIInputViewController {
       // Always start in letters with a new keyboard.
       keyboardState = .letters
       loadKeys()
-      commandBar.text = translatePromptAndCursor
+      commandBar.text = translatePromptAndPlaceholder
 
     // Switch to conjugate state.
     case "Conjugate":
@@ -1099,7 +1099,7 @@ class KeyboardViewController: UIInputViewController {
       commandState = true
       getConjugation = true
       loadKeys()
-      commandBar.text = conjugatePromptAndCursor
+      commandBar.text = conjugatePromptAndPlaceholder
 
     // Switch to plural state.
     case "Plural":
@@ -1112,7 +1112,7 @@ class KeyboardViewController: UIInputViewController {
       commandState = true
       getPlural = true
       loadKeys()
-      commandBar.text = pluralPromptAndCursor
+      commandBar.text = pluralPromptAndPlaceholder
 
     // Move displayed conjugations to the left in order if able.
     case "shiftConjugateLeft":
@@ -1193,6 +1193,8 @@ class KeyboardViewController: UIInputViewController {
       loadKeys()
 
     case "delete":
+      // Inserting the placeholder when commandBar text is deleted
+      commandBar.conditionallyPlacePlaceholder()
       if shiftButtonState == .shift {
         shiftButtonState = .normal
         loadKeys()
@@ -1214,6 +1216,7 @@ class KeyboardViewController: UIInputViewController {
       clearCommandBar()
 
     case spaceBar:
+      commandBar.conditionallyRemovePlaceholder()
       if commandState != true {
         proxy.insertText(" ")
         if [". ", "? ", "! "].contains(proxy.documentContextBeforeInput?.suffix(2)) {
@@ -1356,6 +1359,7 @@ class KeyboardViewController: UIInputViewController {
 
     case "'":
       // Change back to letter keys.
+      commandBar.conditionallyRemovePlaceholder()
       if commandState != true {
         proxy.insertText("'")
       } else {
@@ -1371,6 +1375,7 @@ class KeyboardViewController: UIInputViewController {
       capsLockPossible = true
 
     default:
+      commandBar.conditionallyRemovePlaceholder()
       if shiftButtonState == .shift {
         shiftButtonState = .normal
         loadKeys()
@@ -1474,6 +1479,7 @@ class KeyboardViewController: UIInputViewController {
     // Prevent the command state prompt from being deleted.
     if commandState == true && allPrompts.contains((commandBar?.text!)!) {
       gesture.state = .cancelled
+      commandBar.conditionallyPlacePlaceholder()
     }
     if gesture.state == .began {
       backspaceTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { (_) in

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
@@ -72,4 +72,28 @@ class CommandBar: UILabel {
     self.shadow.backgroundColor = UIColor.clear
     self.blend.backgroundColor = UIColor.clear
   }
+  
+  func conditionallyRemovePlaceholder() {
+    if commandState == true {
+      if getTranslation == true && self.text == translatePromptAndPlaceholder {
+        self.text = translatePromptAndCursor
+      } else if getConjugation == true && self.text == conjugatePromptAndPlaceholder {
+        self.text = conjugatePromptAndCursor
+      } else if getPlural == true && self.text == pluralPromptAndPlaceholder {
+        self.text = pluralPromptAndCursor
+      }
+    }
+  }
+  
+  func conditionallyPlacePlaceholder() {
+    if commandState == true {
+      if getTranslation == true && self.text == translatePromptAndCursor {
+        self.text = translatePromptAndPlaceholder
+      } else if getConjugation == true && self.text == conjugatePromptAndCursor {
+        self.text = conjugatePromptAndPlaceholder
+      } else if getPlural == true && self.text == pluralPromptAndCursor {
+        self.text = pluralPromptAndPlaceholder
+      }
+    }
+  }
 }


### PR DESCRIPTION
- PR for second stage of issue #35 
- Added `conditionallyRemovePlaceholder()` and `conditionallyPlacePlaceholder()` to [CommandBar.swift](https://github.com/scribe-org/Scribe-iOS/blob/6200cbcd8457187b815b67e8316d99261737f944/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift).
- These allow us to remove the placeholder prompt when the user starts typing and re-insert it when the text is deleted.
- Added PromptAndPlaceholder variables to `allPrompts` array to stop the prompt from being deleted.
- Added call to appropriate function for the `default`, `spaceBar`, `"'"`, `delete` and `keyLongPressed` cases.