### PR TITLE
Feat: Adding colour to Placeholder prompts in Command Bar

### DIFF
--- a/Keyboards/KeyboardsBase/Extensions.swift
+++ b/Keyboards/KeyboardsBase/Extensions.swift
@@ -74,3 +74,10 @@ extension StringProtocol {
     return view
   }
 }
+
+extension NSMutableAttributedString {
+    func setColorForText(textForAttribute: String, withColor color: UIColor) {
+        let range: NSRange = self.mutableString.range(of: textForAttribute, options: .caseInsensitive)
+        self.addAttribute(NSAttributedString.Key.foregroundColor, value: color, range: range)
+    }
+}

--- a/Keyboards/KeyboardsBase/InterfaceVariables.swift
+++ b/Keyboards/KeyboardsBase/InterfaceVariables.swift
@@ -119,6 +119,7 @@ func setKeyboardLayout() {
   }
 
   allPrompts = [translatePromptAndCursor, conjugatePromptAndCursor, pluralPromptAndCursor, translatePromptAndPlaceholder, conjugatePromptAndPlaceholder, pluralPromptAndPlaceholder]
+  allColoredPrompts = [translatePromptAndColorPlaceholder, conjugatePromptAndColorPlaceholder, pluralPromptAndColorPlaceholder]
 }
 
 // Variables that define which keys are positioned on the very left, right or in the center of the keyboard.
@@ -257,15 +258,21 @@ func setENKeyboardLayout() {
   translatePrompt = commandPromptSpacing + "en -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
   translatePromptAndPlaceholder = translatePromptAndCursor + " " + translatePlaceholder
+  translatePromptAndColorPlaceholder = NSMutableAttributedString(string: translatePromptAndPlaceholder)
+  translatePromptAndColorPlaceholder.setColorForText(textForAttribute: translatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
 
   conjugateKeyLbl = "Conjugate"
   conjugatePrompt = commandPromptSpacing + "Conjugate: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
   conjugatePromptAndPlaceholder = conjugatePromptAndCursor + " " + conjugatePlaceholder
+  conjugatePromptAndColorPlaceholder = NSMutableAttributedString(string: conjugatePromptAndPlaceholder)
+  conjugatePromptAndColorPlaceholder.setColorForText(textForAttribute: conjugatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
 
   pluralKeyLbl = "Plural"
   pluralPrompt = commandPromptSpacing + "Plural: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
   pluralPromptAndPlaceholder = pluralPromptAndCursor + " " + pluralPlaceholder
+  pluralPromptAndColorPlaceholder = NSMutableAttributedString(string: pluralPromptAndPlaceholder)
+  pluralPromptAndColorPlaceholder.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
   isAlreadyPluralMessage = "Already plural"
 }

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -203,7 +203,7 @@ class KeyboardViewController: UIInputViewController {
   func handleDeleteButtonPressed() {
     if commandState != true {
       proxy.deleteBackward()
-    } else if !(commandState == true && allPrompts.contains(commandBar.text!)) {
+    } else if !(commandState == true && (allPrompts.contains(commandBar.text!) || allColoredPrompts.contains(commandBar.attributedText!))) {
       guard
         let inputText = commandBar.text,
         !inputText.isEmpty
@@ -1091,7 +1091,7 @@ class KeyboardViewController: UIInputViewController {
       // Always start in letters with a new keyboard.
       keyboardState = .letters
       loadKeys()
-      commandBar.text = translatePromptAndPlaceholder
+      commandBar.attributedText = translatePromptAndColorPlaceholder
 
     // Switch to conjugate state.
     case "Conjugate":
@@ -1099,7 +1099,7 @@ class KeyboardViewController: UIInputViewController {
       commandState = true
       getConjugation = true
       loadKeys()
-      commandBar.text = conjugatePromptAndPlaceholder
+      commandBar.attributedText = conjugatePromptAndColorPlaceholder
 
     // Switch to plural state.
     case "Plural":
@@ -1112,7 +1112,7 @@ class KeyboardViewController: UIInputViewController {
       commandState = true
       getPlural = true
       loadKeys()
-      commandBar.text = pluralPromptAndPlaceholder
+      commandBar.attributedText = pluralPromptAndColorPlaceholder
 
     // Move displayed conjugations to the left in order if able.
     case "shiftConjugateLeft":
@@ -1198,9 +1198,12 @@ class KeyboardViewController: UIInputViewController {
         loadKeys()
       }
       // Prevent the command state prompt from being deleted.
-      if commandState == true && allPrompts.contains((commandBar?.text!)!) {
+      if commandState == true && (allPrompts.contains((commandBar?.text!)!) || allColoredPrompts.contains(commandBar.attributedText!)) {
         shiftButtonState = .shift // Auto-capitalization
         loadKeys()
+        // function call required due to return
+        // else placeholder is never added on last delete action
+        commandBar.conditionallyAddPlaceholder()
         return
       }
       handleDeleteButtonPressed()

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
@@ -75,11 +75,11 @@ class CommandBar: UILabel {
   
   func conditionallyRemovePlaceholder() {
     if commandState == true {
-      if getTranslation == true && self.text == translatePromptAndPlaceholder {
-        self.text = translatePromptAndCursor
-      } else if getConjugation == true && self.text == conjugatePromptAndPlaceholder {
+      if getTranslation == true && (self.attributedText?.isEqual(to: translatePromptAndColorPlaceholder) ?? false) {
+        self.attributedText = NSAttributedString(string: translatePromptAndCursor)
+      } else if getConjugation == true && (self.attributedText?.isEqual(to: conjugatePromptAndColorPlaceholder) ?? false) {
         self.text = conjugatePromptAndCursor
-      } else if getPlural == true && self.text == pluralPromptAndPlaceholder {
+      } else if getPlural == true && (self.attributedText?.isEqual(to: pluralPromptAndColorPlaceholder) ?? false) {
         self.text = pluralPromptAndCursor
       }
     }
@@ -87,13 +87,27 @@ class CommandBar: UILabel {
   
   func conditionallyAddPlaceholder() {
     if commandState == true {
-      if getTranslation == true && self.text == translatePromptAndCursor {
-        self.text = translatePromptAndPlaceholder
-      } else if getConjugation == true && self.text == conjugatePromptAndCursor {
-        self.text = conjugatePromptAndPlaceholder
-      } else if getPlural == true && self.text == pluralPromptAndCursor {
-        self.text = pluralPromptAndPlaceholder
+      // self.text check required as attributed text changes to text when shiftButtonState == .shift
+      if getTranslation == true && (self.text == translatePromptAndCursor || self.text == translatePromptAndPlaceholder) {
+        self.attributedText = colorizePrompt(for: translatePromptAndPlaceholder)
+      } else if getConjugation == true && (self.text == conjugatePromptAndCursor || self.text == conjugatePromptAndPlaceholder) {
+        self.attributedText = colorizePrompt(for: conjugatePromptAndPlaceholder)
+      } else if getPlural == true && (self.text == pluralPromptAndCursor || self.text == pluralPromptAndPlaceholder) {
+        self.attributedText = colorizePrompt(for: pluralPromptAndPlaceholder)
       }
     }
+  }
+  
+  func colorizePrompt(for prompt: String) -> NSMutableAttributedString {
+    let colorPrompt = NSMutableAttributedString(string: prompt)
+    if getTranslation == true {
+      colorPrompt.setColorForText(textForAttribute: translatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
+    } else if getConjugation == true {
+      colorPrompt.setColorForText(textForAttribute: conjugatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
+    } else if getPlural == true {
+      colorPrompt.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
+    }
+    
+    return colorPrompt
   }
 }

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
@@ -40,6 +40,7 @@ var switchInput: Bool = false
 
 // Prompts and saving groups of languages.
 var allPrompts: [String] = [""]
+var allColoredPrompts: [NSAttributedString] = []
 
 let languagesWithCapitalizedNouns = ["German"]
 let languagesWithCaseDependantOnPrepositions = ["German", "Russian"]
@@ -50,6 +51,7 @@ var translatePrompt: String = ""
 var translatePlaceholder: String = ""
 var translatePromptAndCursor: String = ""
 var translatePromptAndPlaceholder: String = ""
+var translatePromptAndColorPlaceholder = NSMutableAttributedString()
 var getTranslation: Bool = false
 var wordToTranslate: String = ""
 
@@ -59,6 +61,7 @@ var conjugatePrompt: String = ""
 var conjugatePlaceholder: String = ""
 var conjugatePromptAndCursor: String = ""
 var conjugatePromptAndPlaceholder: String = ""
+var conjugatePromptAndColorPlaceholder = NSMutableAttributedString()
 var getConjugation: Bool = false
 var conjugateView: Bool = false
 var conjugateAlternateView: Bool = false
@@ -101,6 +104,7 @@ var pluralPrompt: String = ""
 var pluralPlaceholder: String = ""
 var pluralPromptAndCursor: String = ""
 var pluralPromptAndPlaceholder: String = ""
+var pluralPromptAndColorPlaceholder = NSMutableAttributedString()
 var getPlural: Bool = false
 var isAlreadyPluralState: Bool = false
 var isAlreadyPluralMessage: String = ""

--- a/Keyboards/LanguageKeyboards/French/FRInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FRInterfaceVariables.swift
@@ -4,6 +4,8 @@
 //  Constants and functions to load the French Scribe keyboard.
 //
 
+import UIKit
+
 public enum FrenchKeyboardConstants {
 
   // Keyboard key layouts.
@@ -113,17 +115,23 @@ func setFRKeyboardLayout() {
   translatePrompt = commandPromptSpacing + "fr -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
   translatePromptAndPlaceholder = translatePromptAndCursor + " " + translatePlaceholder
+  translatePromptAndColorPlaceholder = NSMutableAttributedString(string: translatePromptAndPlaceholder)
+  translatePromptAndColorPlaceholder.setColorForText(textForAttribute: translatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
 
   conjugateKeyLbl = "Conjuguer"
   conjugatePlaceholder = "Entrez un verbe"
   conjugatePrompt = commandPromptSpacing + "Conjuguer: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
   conjugatePromptAndPlaceholder = conjugatePromptAndCursor + " " + conjugatePlaceholder
+  conjugatePromptAndColorPlaceholder = NSMutableAttributedString(string: conjugatePromptAndPlaceholder)
+  conjugatePromptAndColorPlaceholder.setColorForText(textForAttribute: conjugatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
 
   pluralKeyLbl = "Pluriel"
   pluralPlaceholder = "Entrez un nom"
   pluralPrompt = commandPromptSpacing + "Pluriel: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
   pluralPromptAndPlaceholder = pluralPromptAndCursor + " " + pluralPlaceholder
+  pluralPromptAndColorPlaceholder = NSMutableAttributedString(string: pluralPromptAndPlaceholder)
+  pluralPromptAndColorPlaceholder.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
   isAlreadyPluralMessage = "Déjà pluriel"
 }

--- a/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
@@ -4,6 +4,8 @@
 //  Constants and functions to load the German Scribe keyboard.
 //
 
+import UIKit
+
 public enum GermanKeyboardConstants {
 
   // Keyboard key layouts.
@@ -119,17 +121,23 @@ func setDEKeyboardLayout() {
   translatePrompt = commandPromptSpacing + "de -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
   translatePromptAndPlaceholder = translatePromptAndCursor + " " + translatePlaceholder
+  translatePromptAndColorPlaceholder = NSMutableAttributedString(string: translatePromptAndPlaceholder)
+  translatePromptAndColorPlaceholder.setColorForText(textForAttribute: translatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
 
   conjugateKeyLbl = "Konjugieren"
   conjugatePlaceholder = "Verb eingeben"
   conjugatePrompt = commandPromptSpacing + "Konjugieren: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
   conjugatePromptAndPlaceholder = conjugatePromptAndCursor + " " + conjugatePlaceholder
+  conjugatePromptAndColorPlaceholder = NSMutableAttributedString(string: conjugatePromptAndPlaceholder)
+  conjugatePromptAndColorPlaceholder.setColorForText(textForAttribute: conjugatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
 
   pluralKeyLbl = "Plural"
   pluralPlaceholder = "Nomen eingeben"
   pluralPrompt = commandPromptSpacing + "Plural: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
   pluralPromptAndPlaceholder = pluralPromptAndCursor + " " + pluralPlaceholder
+  pluralPromptAndColorPlaceholder = NSMutableAttributedString(string: pluralPromptAndPlaceholder)
+  pluralPromptAndColorPlaceholder.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
   isAlreadyPluralMessage = "Schon Plural"
 }

--- a/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
@@ -4,6 +4,8 @@
 //  Constants and functions to load the Italian Scribe keyboard.
 //
 
+import UIKit
+
 public enum ItalianKeyboardConstants {
 
   // Keyboard key layouts.
@@ -113,17 +115,23 @@ func setITKeyboardLayout() {
   translatePrompt = commandPromptSpacing + "it -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
   translatePromptAndPlaceholder = translatePromptAndCursor + " " + translatePlaceholder
+  translatePromptAndColorPlaceholder = NSMutableAttributedString(string: translatePromptAndPlaceholder)
+  translatePromptAndColorPlaceholder.setColorForText(textForAttribute: translatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
 
   conjugateKeyLbl = "Coniugare"
   conjugatePlaceholder = "Inserisci un verbo"
   conjugatePrompt = commandPromptSpacing + "Coniugare: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
   conjugatePromptAndPlaceholder = conjugatePromptAndCursor + " " + conjugatePlaceholder
+  conjugatePromptAndColorPlaceholder = NSMutableAttributedString(string: conjugatePromptAndPlaceholder)
+  conjugatePromptAndColorPlaceholder.setColorForText(textForAttribute: conjugatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
 
   pluralKeyLbl = "Plurale"
   pluralPlaceholder = "Inserisci un nome"
   pluralPrompt = commandPromptSpacing + "Plurale: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
   pluralPromptAndPlaceholder = pluralPromptAndCursor + " " + pluralPlaceholder
+  pluralPromptAndColorPlaceholder = NSMutableAttributedString(string: pluralPromptAndPlaceholder)
+  pluralPromptAndColorPlaceholder.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
   isAlreadyPluralMessage = "Già plurale"
 }

--- a/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
@@ -4,6 +4,8 @@
 //  Constants and functions to load the Portuguese Scribe keyboard.
 //
 
+import UIKit
+
 public enum PortugueseKeyboardConstants {
 
   // Keyboard key layouts.
@@ -111,17 +113,23 @@ func setPTKeyboardLayout() {
   translatePrompt = commandPromptSpacing + "pt -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
   translatePromptAndPlaceholder = translatePromptAndCursor + " " + translatePlaceholder
+  translatePromptAndColorPlaceholder = NSMutableAttributedString(string: translatePromptAndPlaceholder)
+  translatePromptAndColorPlaceholder.setColorForText(textForAttribute: translatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
 
   conjugateKeyLbl = "Conjugar"
   conjugatePlaceholder = "Digite um verbo"
   conjugatePrompt = commandPromptSpacing + "Conjugar: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
   conjugatePromptAndPlaceholder = conjugatePromptAndCursor + " " + conjugatePlaceholder
+  conjugatePromptAndColorPlaceholder = NSMutableAttributedString(string: conjugatePromptAndPlaceholder)
+  conjugatePromptAndColorPlaceholder.setColorForText(textForAttribute: conjugatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
 
   pluralKeyLbl = "Plural"
   pluralPlaceholder = "Digite um substantivo"
   pluralPrompt = commandPromptSpacing + "Plural: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
   pluralPromptAndPlaceholder = pluralPromptAndCursor + " " + pluralPlaceholder
+  pluralPromptAndColorPlaceholder = NSMutableAttributedString(string: pluralPromptAndPlaceholder)
+  pluralPromptAndColorPlaceholder.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
   isAlreadyPluralMessage = "Já plural"
 }

--- a/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
@@ -4,6 +4,8 @@
 //  Constants and functions to load the Russian Scribe keyboard.
 //
 
+import UIKit
+
 public enum RussianKeyboardConstants {
 
   // Keyboard key layouts.
@@ -101,17 +103,23 @@ func setRUKeyboardLayout() {
   translatePrompt = commandPromptSpacing + "ru -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
   translatePromptAndPlaceholder = translatePromptAndCursor + " " + translatePlaceholder
+  translatePromptAndColorPlaceholder = NSMutableAttributedString(string: translatePromptAndPlaceholder)
+  translatePromptAndColorPlaceholder.setColorForText(textForAttribute: translatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
 
   conjugateKeyLbl = "Спрягать"
   conjugatePlaceholder = "Введите глагол"
   conjugatePrompt = commandPromptSpacing + "Спрягать: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
   conjugatePromptAndPlaceholder = conjugatePromptAndCursor + " " + conjugatePlaceholder
+  conjugatePromptAndColorPlaceholder = NSMutableAttributedString(string: conjugatePromptAndPlaceholder)
+  conjugatePromptAndColorPlaceholder.setColorForText(textForAttribute: conjugatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
 
   pluralKeyLbl = "Множ"
   pluralPlaceholder = "Введите существительное"
   pluralPrompt = commandPromptSpacing + "Множ: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
   pluralPromptAndPlaceholder = pluralPromptAndCursor + " " + pluralPlaceholder
+  pluralPromptAndColorPlaceholder = NSMutableAttributedString(string: pluralPromptAndPlaceholder)
+  pluralPromptAndColorPlaceholder.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
   isAlreadyPluralMessage = "Уже во множ"
 }

--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -4,6 +4,8 @@
 //  Constants and functions to load the Spanish Scribe keyboard.
 //
 
+import UIKit
+
 public class SpanishKeyboardConstants {
 
   // Keyboard key layouts.
@@ -115,17 +117,23 @@ func setESKeyboardLayout() {
   translatePrompt = commandPromptSpacing + "es -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
   translatePromptAndPlaceholder = translatePromptAndCursor + " " + translatePlaceholder
+  translatePromptAndColorPlaceholder = NSMutableAttributedString(string: translatePromptAndPlaceholder)
+  translatePromptAndColorPlaceholder.setColorForText(textForAttribute: translatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
 
   conjugateKeyLbl = "Conjugar"
   conjugatePlaceholder = "Ingresar un verbo"
   conjugatePrompt = commandPromptSpacing + "Conjugar: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
   conjugatePromptAndPlaceholder = conjugatePromptAndCursor + " " + conjugatePlaceholder
+  conjugatePromptAndColorPlaceholder = NSMutableAttributedString(string: conjugatePromptAndPlaceholder)
+  conjugatePromptAndColorPlaceholder.setColorForText(textForAttribute: conjugatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
 
   pluralKeyLbl = "Plural"
   pluralPlaceholder = "Ingrese un sustantivo"
   pluralPrompt = commandPromptSpacing + "Plural: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
   pluralPromptAndPlaceholder = pluralPromptAndCursor + " " + pluralPlaceholder
+  pluralPromptAndColorPlaceholder = NSMutableAttributedString(string: pluralPromptAndPlaceholder)
+  pluralPromptAndColorPlaceholder.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
   isAlreadyPluralMessage = "Ya en plural"
 }

--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-public class SpanishKeyboardConstants {
+public enum SpanishKeyboardConstants {
 
   // Keyboard key layouts.
   static let letterKeysPhone = [

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-public class SwedishKeyboardConstants {
+public enum SwedishKeyboardConstants {
 
   // Keyboard key layouts.
   static let letterKeysPhone = [

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -4,6 +4,8 @@
 //  Constants and functions to load the Swedish Scribe keyboard.
 //
 
+import UIKit
+
 public class SwedishKeyboardConstants {
 
   // Keyboard key layouts.
@@ -117,17 +119,23 @@ func setSVKeyboardLayout() {
   translatePrompt = commandPromptSpacing + "sv -› \(getControllerLanguageAbbr()): "
   translatePromptAndCursor = translatePrompt + commandCursor
   translatePromptAndPlaceholder = translatePromptAndCursor + " " + translatePlaceholder
+  translatePromptAndColorPlaceholder = NSMutableAttributedString(string: translatePromptAndPlaceholder)
+  translatePromptAndColorPlaceholder.setColorForText(textForAttribute: translatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
 
   conjugateKeyLbl = "Konjugera"
   conjugatePlaceholder = "Ange ett verb"
   conjugatePrompt = commandPromptSpacing + "Konjugera: "
   conjugatePromptAndCursor = conjugatePrompt + commandCursor
   conjugatePromptAndPlaceholder = conjugatePromptAndCursor + " " + conjugatePlaceholder
+  conjugatePromptAndColorPlaceholder = NSMutableAttributedString(string: conjugatePromptAndPlaceholder)
+  conjugatePromptAndColorPlaceholder.setColorForText(textForAttribute: conjugatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
 
   pluralKeyLbl = "Plural"
   pluralPlaceholder = "Ange ett substantiv"
   pluralPrompt = commandPromptSpacing + "Plural: "
   pluralPromptAndCursor = pluralPrompt + commandCursor
   pluralPromptAndPlaceholder = pluralPromptAndCursor + " " + pluralPlaceholder
+  pluralPromptAndColorPlaceholder = NSMutableAttributedString(string: pluralPromptAndPlaceholder)
+  pluralPromptAndColorPlaceholder.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
   isAlreadyPluralMessage = "Redan plural"
 }

--- a/Scribe.xcodeproj/project.pbxproj
+++ b/Scribe.xcodeproj/project.pbxproj
@@ -444,7 +444,7 @@
 		D17193BF27AEA33A0038660B /* AppTextStyling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTextStyling.swift; sourceTree = "<group>"; };
 		D17193C327AEAD7D0038660B /* AppStyling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStyling.swift; sourceTree = "<group>"; };
 		D17193C527AEC8D20038660B /* FRInterfaceVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRInterfaceVariables.swift; sourceTree = "<group>"; };
-		D17193CF27AEC9EC0038660B /* DEInterfaceVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DEInterfaceVariables.swift; sourceTree = "<group>"; };
+		D17193CF27AEC9EC0038660B /* DEInterfaceVariables.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = DEInterfaceVariables.swift; sourceTree = "<group>"; tabWidth = 2; };
 		D17193D727AECA450038660B /* PTInterfaceVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTInterfaceVariables.swift; sourceTree = "<group>"; };
 		D17193DF27AECAA60038660B /* RUInterfaceVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUInterfaceVariables.swift; sourceTree = "<group>"; };
 		D17193E727AECAE60038660B /* ESInterfaceVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ESInterfaceVariables.swift; sourceTree = "<group>"; };
@@ -572,7 +572,9 @@
 				D1362A37274C040F00C00E48 /* PRIVACY.txt */,
 				38BD213122D5907E00C6795D /* Products */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
 		};
 		38BD213122D5907E00C6795D /* Products */ = {
 			isa = PBXGroup;

--- a/Scribe.xcodeproj/project.pbxproj
+++ b/Scribe.xcodeproj/project.pbxproj
@@ -444,7 +444,7 @@
 		D17193BF27AEA33A0038660B /* AppTextStyling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTextStyling.swift; sourceTree = "<group>"; };
 		D17193C327AEAD7D0038660B /* AppStyling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStyling.swift; sourceTree = "<group>"; };
 		D17193C527AEC8D20038660B /* FRInterfaceVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRInterfaceVariables.swift; sourceTree = "<group>"; };
-		D17193CF27AEC9EC0038660B /* DEInterfaceVariables.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = DEInterfaceVariables.swift; sourceTree = "<group>"; tabWidth = 2; };
+		D17193CF27AEC9EC0038660B /* DEInterfaceVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DEInterfaceVariables.swift; sourceTree = "<group>"; tabWidth = 2; };
 		D17193D727AECA450038660B /* PTInterfaceVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTInterfaceVariables.swift; sourceTree = "<group>"; };
 		D17193DF27AECAA60038660B /* RUInterfaceVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUInterfaceVariables.swift; sourceTree = "<group>"; };
 		D17193E727AECAE60038660B /* ESInterfaceVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ESInterfaceVariables.swift; sourceTree = "<group>"; };
@@ -572,9 +572,7 @@
 				D1362A37274C040F00C00E48 /* PRIVACY.txt */,
 				38BD213122D5907E00C6795D /* Products */,
 			);
-			indentWidth = 2;
 			sourceTree = "<group>";
-			tabWidth = 2;
 		};
 		38BD213122D5907E00C6795D /* Products */ = {
 			isa = PBXGroup;

--- a/Scribe.xcodeproj/project.pbxproj
+++ b/Scribe.xcodeproj/project.pbxproj
@@ -444,7 +444,7 @@
 		D17193BF27AEA33A0038660B /* AppTextStyling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTextStyling.swift; sourceTree = "<group>"; };
 		D17193C327AEAD7D0038660B /* AppStyling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStyling.swift; sourceTree = "<group>"; };
 		D17193C527AEC8D20038660B /* FRInterfaceVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRInterfaceVariables.swift; sourceTree = "<group>"; };
-		D17193CF27AEC9EC0038660B /* DEInterfaceVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DEInterfaceVariables.swift; sourceTree = "<group>"; tabWidth = 2; };
+		D17193CF27AEC9EC0038660B /* DEInterfaceVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DEInterfaceVariables.swift; sourceTree = "<group>"; };
 		D17193D727AECA450038660B /* PTInterfaceVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTInterfaceVariables.swift; sourceTree = "<group>"; };
 		D17193DF27AECAA60038660B /* RUInterfaceVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RUInterfaceVariables.swift; sourceTree = "<group>"; };
 		D17193E727AECAE60038660B /* ESInterfaceVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ESInterfaceVariables.swift; sourceTree = "<group>"; };


### PR DESCRIPTION
- PR for the final stage of issue #35 
- Added a colorize function that returns an `NSMuttableAttributedString` to assign to the prompt in `CommandBar.swift`
- Made changes to all language keyboard interface variables to hold colored prompts that allow for checks during conditionally removing and adding the placeholder.
- Colorized prompt uses `commandBarBorderColorLight` or `commandBarBorderColorDark` depending on the appearance mode.
- Added an extension to `NSMuttableAttributedString` that allow us to color the required part of the prompt using a single function.

@andrewtavis please review these changes. This task was a big learning experience! Thanks! 😊