### PR TITLE
Fix: Changing Scribe-org link to Scribe-iOS repo link

### DIFF
--- a/Scribe/AppTexts/English/ENAppText.swift
+++ b/Scribe/AppTexts/English/ENAppText.swift
@@ -111,7 +111,7 @@ func getENGitHubText(fontSize: CGFloat) -> NSMutableAttributedString {
   // A second NSAttributedString that includes a link to the GitHub.
   let ghLink = addHyperLinks(
     originalText: "github.com/scribe-org.",
-    links: ["github.com/scribe-org": "https://github.com/scribe-org"],
+    links: ["github.com/scribe-org": "https://github.com/scribe-org/Scribe-iOS"],
     fontSize: fontSize
   )
 

--- a/Scribe/ViewController.swift
+++ b/Scribe/ViewController.swift
@@ -302,7 +302,7 @@ class ViewController: UIViewController {
 
   /// Function to open Scribe's GitHub page that is targeted by GHBtn.
   @objc func openScribeGH() {
-    guard let url = URL(string: "https://github.com/scribe-org") else {
+    guard let url = URL(string: "https://github.com/scribe-org/Scribe-iOS") else {
       return
     }
 


### PR DESCRIPTION
- PR for issue #178 
- Changed URL to direct to Scribe-iOS repository in files `ViewController.swift` and `ENAppText.swift` instead of the Scribe-org page.

@andrewtavis, please review these changes. Thank you :)