### PR TITLE
UI: Changing return key symbol to arrowTriangle.right.fill

### DIFF
--- a/Keyboards/KeyboardsBase/KeyboardStyling.swift
+++ b/Keyboards/KeyboardsBase/KeyboardStyling.swift
@@ -35,7 +35,8 @@ var keysThatAreSlightlyLarger: [String] = [
   "chevron.right",
   "shift",
   "shift.fill",
-  "capslock.fill"
+  "capslock.fill",
+  "arrowtriangle.right.fill"
 ]
 
 /// Get the icon configurations for keys if the device is an iPhone.

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -880,7 +880,7 @@ class KeyboardViewController: UIInputViewController {
           }
 
           if key == "return" {
-            styleIconBtn(btn: btn, color: keyCharColor, iconName: "arrowtriangle.right.fill")
+              styleIconBtn(btn: btn, color: keyCharColor, iconName: commandState ? "arrowtriangle.right.fill" : "arrow.turn.down.left")
           }
 
           if key == "delete" {

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -880,7 +880,7 @@ class KeyboardViewController: UIInputViewController {
           }
 
           if key == "return" {
-            styleIconBtn(btn: btn, color: keyCharColor, iconName: "arrow.turn.down.left")
+            styleIconBtn(btn: btn, color: keyCharColor, iconName: "arrowtriangle.right.fill")
           }
 
           if key == "delete" {

--- a/Scribe/AppTexts/AppTextStyling.swift
+++ b/Scribe/AppTexts/AppTextStyling.swift
@@ -59,7 +59,7 @@ func getArrowIcon(fontSize: CGFloat) -> NSAttributedString {
   let arrowAttachment = NSTextAttachment()
   let selectArrowIconConfig = UIImage.SymbolConfiguration(pointSize: fontSize, weight: .medium, scale: .medium)
   arrowAttachment.image = UIImage(
-    systemName: "arrowtriangle.right.fill",
+    systemName: "arrow.turn.down.left",
     withConfiguration: selectArrowIconConfig
   )?.withTintColor(.scribeGrey)
 

--- a/Scribe/AppTexts/AppTextStyling.swift
+++ b/Scribe/AppTexts/AppTextStyling.swift
@@ -59,7 +59,7 @@ func getArrowIcon(fontSize: CGFloat) -> NSAttributedString {
   let arrowAttachment = NSTextAttachment()
   let selectArrowIconConfig = UIImage.SymbolConfiguration(pointSize: fontSize, weight: .medium, scale: .medium)
   arrowAttachment.image = UIImage(
-    systemName: "arrow.turn.down.right",
+    systemName: "arrowtriangle.right.fill",
     withConfiguration: selectArrowIconConfig
   )?.withTintColor(.scribeGrey)
 

--- a/Scribe/AppTexts/AppTextStyling.swift
+++ b/Scribe/AppTexts/AppTextStyling.swift
@@ -59,7 +59,7 @@ func getArrowIcon(fontSize: CGFloat) -> NSAttributedString {
   let arrowAttachment = NSTextAttachment()
   let selectArrowIconConfig = UIImage.SymbolConfiguration(pointSize: fontSize, weight: .medium, scale: .medium)
   arrowAttachment.image = UIImage(
-    systemName: "arrow.turn.down.left",
+    systemName: "arrow.turn.down.right",
     withConfiguration: selectArrowIconConfig
   )?.withTintColor(.scribeGrey)
 


### PR DESCRIPTION
- PR for issue #165 
- Changed `arrow.turn.down.left` to` arrowTriangle.right.fill` in files [AppTextStyling.swift](https://github.com/scribe-org/Scribe-iOS/blob/bddbaaa1805d244f852ac46ec07eb47e4b253c0a/Scribe/AppTexts/AppTextStyling.swift) and [KeyboardViewController.swift](https://github.com/scribe-org/Scribe-iOS/blob/bddbaaa1805d244f852ac46ec07eb47e4b253c0a/Keyboards/KeyboardsBase/KeyboardViewController.swift)
- Added required symbol to [keysThatAreSlightlyLarger](https://github.com/scribe-org/Scribe-iOS/blob/bddbaaa1805d244f852ac46ec07eb47e4b253c0a/Keyboards/KeyboardsBase/KeyboardStyling.swift#L32) array to increase the size of the symbol relative to the other keys.

@andrewtavis, please review these changes at your convenience. Thank you so much 😊