### PR TITLE
#184 fix placeholder deletion and add fxn docstrings

### DIFF
--- a/Keyboards/KeyboardsBase/InterfaceVariables.swift
+++ b/Keyboards/KeyboardsBase/InterfaceVariables.swift
@@ -118,7 +118,10 @@ func setKeyboardLayout() {
     setLayoutFxn()
   }
 
+  // Variable type is String.
   allPrompts = [translatePromptAndCursor, conjugatePromptAndCursor, pluralPromptAndCursor, translatePromptAndPlaceholder, conjugatePromptAndPlaceholder, pluralPromptAndPlaceholder]
+
+  // Variable type is NSAttributedString.
   allColoredPrompts = [translatePromptAndColorPlaceholder, conjugatePromptAndColorPlaceholder, pluralPromptAndColorPlaceholder]
 }
 

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -222,7 +222,7 @@ class KeyboardViewController: UIInputViewController {
   @IBOutlet var scribeKeyShadow: UIButton!
 
   /// Links various UI elements that interact concurrently.
-  func linkElements() {
+  func linkShadowBlendElements() {
     scribeKey.shadow = scribeKeyShadow
     commandBar.shadow = commandBarShadow
     commandBar.blend = commandBarBlend
@@ -650,7 +650,7 @@ class KeyboardViewController: UIInputViewController {
 
     setCommandBackground()
     setKeyboard()
-    linkElements()
+    linkShadowBlendElements()
     setCommandBtns()
     setConjugationBtns()
     invalidState = false
@@ -778,9 +778,9 @@ class KeyboardViewController: UIInputViewController {
         deactivateBtn(btn: pluralKey)
 
         commandBar.setCornerRadiusAndShadow()
-
         if commandState == false {
           commandBar.text = ""
+          commandBar.textColor = keyCharColor
         }
         commandBar.sizeToFit()
       }
@@ -857,8 +857,8 @@ class KeyboardViewController: UIInputViewController {
 
           // Special key styling.
           if key == "delete" {
-            let longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(keyLongPressed(_:)))
-            btn.addGestureRecognizer(longPressRecognizer)
+            let deleteLongPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(deleteLongPressed(_:)))
+            btn.addGestureRecognizer(deleteLongPressRecognizer)
           }
 
           if key == "selectKeyboard" {
@@ -1201,8 +1201,8 @@ class KeyboardViewController: UIInputViewController {
       if commandState == true && (allPrompts.contains((commandBar?.text!)!) || allColoredPrompts.contains(commandBar.attributedText!)) {
         shiftButtonState = .shift // Auto-capitalization
         loadKeys()
-        // function call required due to return
-        // else placeholder is never added on last delete action
+        // Function call required due to return.
+        // Not including means placeholder is never added on last delete action.
         commandBar.conditionallyAddPlaceholder()
         return
       }
@@ -1215,7 +1215,7 @@ class KeyboardViewController: UIInputViewController {
         }
       }
       clearCommandBar()
-      // Inserting the placeholder when commandBar text is deleted
+      // Inserting the placeholder when commandBar text is deleted.
       commandBar.conditionallyAddPlaceholder()
 
     case spaceBar:
@@ -1474,11 +1474,11 @@ class KeyboardViewController: UIInputViewController {
     }
   }
 
-  /// Defines the criteria under which a key is long pressed.
+  /// Defines the criteria under which delete is long pressed.
   ///
   /// - Parameters
   ///   - gesture: the gesture that was received.
-  @objc func keyLongPressed(_ gesture: UIGestureRecognizer) {
+  @objc func deleteLongPressed(_ gesture: UIGestureRecognizer) {
     // Prevent the command state prompt from being deleted.
     if commandState == true && allPrompts.contains((commandBar?.text!)!) {
       gesture.state = .cancelled

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
@@ -50,7 +50,6 @@ class CommandBar: UILabel {
     self.clipsToBounds = true
     self.layer.cornerRadius = commandKeyCornerRadius
     self.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMaxXMaxYCorner]
-    self.textColor = keyCharColor
     self.lineBreakMode = NSLineBreakMode.byWordWrapping
 
     self.shadow.backgroundColor = specialKeyColor
@@ -72,22 +71,22 @@ class CommandBar: UILabel {
     self.shadow.backgroundColor = UIColor.clear
     self.blend.backgroundColor = UIColor.clear
   }
-  
+
+  // Removes the placeholder text for a command and replaces it with just the prompt and cursor.
   func conditionallyRemovePlaceholder() {
-    if commandState == true {
-      if getTranslation == true && (self.attributedText?.isEqual(to: translatePromptAndColorPlaceholder) ?? false) {
-        self.attributedText = NSAttributedString(string: translatePromptAndCursor)
-      } else if getConjugation == true && (self.attributedText?.isEqual(to: conjugatePromptAndColorPlaceholder) ?? false) {
-        self.text = conjugatePromptAndCursor
-      } else if getPlural == true && (self.attributedText?.isEqual(to: pluralPromptAndColorPlaceholder) ?? false) {
-        self.text = pluralPromptAndCursor
-      }
+    if self.text == translatePromptAndPlaceholder {
+      self.text = translatePromptAndCursor
+    } else if self.text == conjugatePromptAndPlaceholder {
+      self.text = conjugatePromptAndCursor
+    } else if self.text == pluralPromptAndPlaceholder {
+      self.text = pluralPromptAndCursor
     }
   }
-  
+
+  // Changes the command bar text to an attributed string with a placeholder if there is no entered characters.
   func conditionallyAddPlaceholder() {
     if commandState == true {
-      // self.text check required as attributed text changes to text when shiftButtonState == .shift
+      // self.text check required as attributed text changes to text when shiftButtonState == .shift.
       if getTranslation == true && (self.text == translatePromptAndCursor || self.text == translatePromptAndPlaceholder) {
         self.attributedText = colorizePrompt(for: translatePromptAndPlaceholder)
       } else if getConjugation == true && (self.text == conjugatePromptAndCursor || self.text == conjugatePromptAndPlaceholder) {
@@ -97,7 +96,8 @@ class CommandBar: UILabel {
       }
     }
   }
-  
+
+  // Changes the color of the placeholder text to indicate that it is temporary.
   func colorizePrompt(for prompt: String) -> NSMutableAttributedString {
     let colorPrompt = NSMutableAttributedString(string: prompt)
     if getTranslation == true {
@@ -107,7 +107,7 @@ class CommandBar: UILabel {
     } else if getPlural == true {
       colorPrompt.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
     }
-    
+
     return colorPrompt
   }
 }


### PR DESCRIPTION
Fixes #184 and has a few added parts. Included is:

- Adding some comments and docstrings to new functions added in #35, as well as formatting some comments that weren't written as complete sentences.
    - Not sure if this is right, but I follow Python comment standards: comments that are their own line are sentences that should start with a capital letter and end with a period as they are complete sentences; inline comments don't need capitalization or periods.
- Renaming some variables and functions that I originally named very poorly and made the debug process way more tedious 🤦‍♂️
- Extracting `commandBar.textColor = keyCharColor` out of `CommandBar.setCornerRadiusAndShadow()`.
- Simplifying the implementation of `conditionallyRemovePlaceholder`:
    - No need for `commandState == true` as it always will be true.
    - No need for `getTranslation == true` and the like as the check can just occur via what the prompt and placeholder are.
    - Switch the `self.attributedText` check to a `self.text` check as this was causing the bug where pressing a non-delete special key would then cause further typing to input the characters after the placeholder rather than remove the placeholder and put the characters after the prompt.

Not sure exactly why the `self.attributedText` check was causing the above bug 🤔 Seemed logical to me when I did my original review. This seems to work though.