### PR TITLE
Adding functions for autocomplete and assigning buttons

### DIFF
--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
@@ -19,6 +19,9 @@ let nouns = loadJSONToDict(filename: "nouns")
 let verbs = loadJSONToDict(filename: "verbs")
 let translations = loadJSONToDict(filename: "translations")
 let prepositions = loadJSONToDict(filename: "prepositions")
+var currentPrefix: String = ""
+var pastStringInTextProxy: String = ""
+var completionWords = [String]()
 
 // A larger vertical bar than the normal | key for the cursor.
 let commandCursor: String = "│"


### PR DESCRIPTION
- PR for second part issue #188 
- Added the required function that generate the next three words alphabetically for autocomplete.
- Set the buttons with the the appropriate text based on this array.
- This function takes into account only one word at a time. 
  - That is when you enter a word and move to the next word in the sentence, it will suggest autocomplete only for that word.
  - Also replaces the typed word with the auto completion instead of just adding it to the end of the user input.

@andrewtavis could you please review these changes! It was so nice to walk through the problem with you. No way was I otherwise figuring it out 😂

Thanks for the help!