### PR TITLE
Fixing gaps in autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+See the [releases for Scribe-iOS](https://github.com/scribe-org/Scribe-iOS/releases) for an up to date list of versions and their release dates. Versions that are marked as released may yet to be in the App Store if it's within the 48 hour submission review period.
+
 Scribe-iOS tries to follow [semantic versioning](https://semver.org/), a MAJOR.MINOR.PATCH version where increments are made of the:
 
 - MAJOR version when we make incompatible API changes
@@ -12,8 +14,8 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 
 ### ✨ New Features
 
-- Scribe now includes a baseline autocomplete feature that suggests the next possible noun based on the current word being entered.
-- Scribe now includes a baseline autosuggest feature that suggests words from a list of most common words in the language.
+<!-- - Scribe now includes a baseline autocomplete feature that suggests the next possible noun based on the current word being entered.
+- Scribe now includes a baseline autosuggest feature that suggests words from a list of most common words in the language. -->
 
 ### 🗃️ Data Added
 

--- a/Keyboards/KeyboardsBase/Extensions.swift
+++ b/Keyboards/KeyboardsBase/Extensions.swift
@@ -60,6 +60,10 @@ extension String {
       $1 == char ? $0 + 1 : $0
     }
   }
+  
+  func capitalizingFirstLetter() -> String {
+    return prefix(1).uppercased() + self.lowercased().dropFirst()
+  }
 }
 
 /// Adds the ability to efficiently trim whitespace at the end of a string.

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -228,7 +228,7 @@ class KeyboardViewController: UIInputViewController {
             if shiftButtonState == .caps {
               completionWords[i] = stringOptions[i].uppercased()
             } else {
-              completionWords[i] = currentPrefix == currentPrefix.capitalized ? stringOptions[i] : stringOptions[i].lowercased() // Capital autocomplete if the user starts typing capitalized.
+              completionWords[i] = currentPrefix == currentPrefix.capitalized ? stringOptions[i].capitalizingFirstLetter() : stringOptions[i].lowercased() // Capital autocomplete if the user starts typing capitalized.
             }
             i += 1
           }
@@ -237,7 +237,7 @@ class KeyboardViewController: UIInputViewController {
               if shiftButtonState == .caps {
                 completionWords[i] = stringOptions[i].uppercased()
               } else {
-                completionWords[i] = currentPrefix == currentPrefix.capitalized ? stringOptions[i] : stringOptions[i].lowercased() // Capital autocomplete if the user starts typing capitalized.
+                completionWords[i] = currentPrefix == currentPrefix.capitalized ? stringOptions[i].capitalizingFirstLetter() : stringOptions[i].lowercased() // Capital autocomplete if the user starts typing capitalized.
               }
                 i += 1
             }

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -1470,6 +1470,8 @@ class KeyboardViewController: UIInputViewController {
         clearCommandBar()
       }
       doubleSpacePeriodPossible = true
+      pastStringInTextProxy = proxy.documentContextBeforeInput ?? ""
+      conditionallySetAutoActionBtns()
 
     case "selectKeyboard":
       self.advanceToNextInputMode()

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -225,12 +225,12 @@ class KeyboardViewController: UIInputViewController {
         var i = 0
         if stringOptions.count <= 3 {
           while i < stringOptions.count {
-            completionWords[i] = pastStringInTextProxy.isEmpty ? stringOptions[i] : stringOptions[i].lowercased() // Lowercase if it is the first word.
+            completionWords[i] = currentPrefix == currentPrefix.capitalized ? stringOptions[i] : stringOptions[i].lowercased() // Capital autocomplete if the user starts typing capitalized.
             i += 1
           }
         } else {
             while i < 3 {
-              completionWords[i] = pastStringInTextProxy.isEmpty ? stringOptions[i] : stringOptions[i].lowercased()
+              completionWords[i] = currentPrefix == currentPrefix.capitalized ? stringOptions[i] : stringOptions[i].lowercased()
                 i += 1
             }
         }

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -266,6 +266,27 @@ class KeyboardViewController: UIInputViewController {
       }
     }
   }
+  
+  /// Function that changes variables pastStringInTextProxy and secondaryPastStringOnDelete.
+  /// Allows for autocomplete to work when delete is pressed by reversing the changes in the above variables.
+  func changePastTextsFromProxy() {
+    if proxy.documentContextBeforeInput?.count == 0 {
+      pastStringInTextProxy = ""
+      secondaryPastStringOnDelete = ""
+    } else {
+      let stringInProxy = proxy.documentContextBeforeInput!
+      if pastStringInTextProxy == stringInProxy {
+        pastStringInTextProxy = secondaryPastStringOnDelete
+        
+        if !secondaryPastStringOnDelete.isEmpty {
+          secondaryPastStringOnDelete.removeLast()
+        }
+        while !secondaryPastStringOnDelete.isEmpty && !secondaryPastStringOnDelete.hasSuffix(" ") {
+          secondaryPastStringOnDelete.removeLast()
+        }
+      } else { return }
+    }
+  }
 
   /// Hides the partitions for autocomplete and autosuggest.
   /// Note: this function is called during command mode when the commandBar is viewable.
@@ -299,6 +320,7 @@ class KeyboardViewController: UIInputViewController {
 
   /// Deletes in the proxy or command bar given the current constraints.
   func handleDeleteButtonPressed() {
+    changePastTextsFromProxy()
     if commandState != true {
       proxy.deleteBackward()
     } else if !(commandState == true && (allPrompts.contains(commandBar.text!) || allColoredPrompts.contains(commandBar.attributedText!))) {
@@ -1336,6 +1358,7 @@ class KeyboardViewController: UIInputViewController {
       proxy.insertText(translateKey.titleLabel?.text ?? "")
       proxy.insertText(" ")
       currentPrefix = ""
+      secondaryPastStringOnDelete = pastStringInTextProxy
       pastStringInTextProxy = proxy.documentContextBeforeInput ?? ""
       clearCommandBar()
       // Prevent annotations from being triggered during commands.
@@ -1359,6 +1382,7 @@ class KeyboardViewController: UIInputViewController {
       proxy.insertText(conjugateKey.titleLabel?.text ?? "")
       proxy.insertText(" ")
       currentPrefix = ""
+      secondaryPastStringOnDelete = pastStringInTextProxy
       pastStringInTextProxy = proxy.documentContextBeforeInput ?? ""
       clearCommandBar()
       // Prevent annotations from being triggered during commands.
@@ -1382,6 +1406,7 @@ class KeyboardViewController: UIInputViewController {
       proxy.insertText(pluralKey.titleLabel?.text ?? "")
       proxy.insertText(" ")
       currentPrefix = ""
+      secondaryPastStringOnDelete = pastStringInTextProxy
       pastStringInTextProxy = proxy.documentContextBeforeInput ?? ""
       clearCommandBar()
       // Prevent annotations from being triggered during commands.
@@ -1426,6 +1451,7 @@ class KeyboardViewController: UIInputViewController {
       clearCommandBar()
       // Inserting the placeholder when commandBar text is deleted.
       commandBar.conditionallyAddPlaceholder()
+      conditionallySetAutoActionBtns()
 
     case spaceBar:
       commandBar.conditionallyRemovePlaceholder()
@@ -1450,6 +1476,11 @@ class KeyboardViewController: UIInputViewController {
           changeKeyboardToLetterKeys()
         }
       }
+      
+      secondaryPastStringOnDelete = pastStringInTextProxy
+      pastStringInTextProxy = proxy.documentContextBeforeInput ?? ""
+      conditionallySetAutoActionBtns()
+      
       // Prevent annotations from being triggered during commands.
       if getConjugation == false && getTranslation == false {
         typedNounAnnotation(
@@ -1470,9 +1501,7 @@ class KeyboardViewController: UIInputViewController {
         clearCommandBar()
       }
       doubleSpacePeriodPossible = true
-      pastStringInTextProxy = proxy.documentContextBeforeInput ?? ""
-      conditionallySetAutoActionBtns()
-
+      
     case "selectKeyboard":
       self.advanceToNextInputMode()
 

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -225,12 +225,20 @@ class KeyboardViewController: UIInputViewController {
         var i = 0
         if stringOptions.count <= 3 {
           while i < stringOptions.count {
-            completionWords[i] = currentPrefix == currentPrefix.capitalized ? stringOptions[i] : stringOptions[i].lowercased() // Capital autocomplete if the user starts typing capitalized.
+            if shiftButtonState == .caps {
+              completionWords[i] = stringOptions[i].uppercased()
+            } else {
+              completionWords[i] = currentPrefix == currentPrefix.capitalized ? stringOptions[i] : stringOptions[i].lowercased() // Capital autocomplete if the user starts typing capitalized.
+            }
             i += 1
           }
         } else {
             while i < 3 {
-              completionWords[i] = currentPrefix == currentPrefix.capitalized ? stringOptions[i] : stringOptions[i].lowercased()
+              if shiftButtonState == .caps {
+                completionWords[i] = stringOptions[i].uppercased()
+              } else {
+                completionWords[i] = currentPrefix == currentPrefix.capitalized ? stringOptions[i] : stringOptions[i].lowercased() // Capital autocomplete if the user starts typing capitalized.
+              }
                 i += 1
             }
         }

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
@@ -27,6 +27,7 @@ let autocompleteWords = nouns!.keys.filter(
 
 var currentPrefix: String = ""
 var pastStringInTextProxy: String = ""
+var secondaryPastStringOnDelete: String = ""
 var completionWords = [String]()
 
 // A larger vertical bar than the normal | key for the cursor.


### PR DESCRIPTION
- PR for part of issue #188 
- Fixed no capitalisation issue and added cases for CapsLock.
- Fixed autocomplete to work even when delete is pressed.
  - This works by having a secondary variable called `secondaryPastStringOnDelete` that stores the previous version of the text in proxy. That way we can return the `pastStringInTextProxy` to the previous line.

@andrewtavis, could you please review these changes. Also could you look into the bug that crashes the keyboard when `delete` is pressed consecutively when the text proxy is empty? I mentioned the exact nature of it in the main issue comments.