### PR TITLE
#188 refactoring incl commandState to enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 
 ### ✨ New Features
 
-<!-- - Scribe now includes a baseline autocomplete feature that suggests the next possible noun based on the current word being entered as well as conjugations of common verbs.
-- Scribe now includes a baseline autosuggest feature that suggests words words derived from Wikipedia as following a given word. -->
+<!-- - Scribe now includes a baseline autocomplete feature that suggests the next possible noun based on the current word being entered as well as the most common words in the keyboard language.
+- Scribe now includes a baseline autosuggest feature that suggests words derived from Wikipedia that most often follow a given word. -->
 
 ### 🗃️ Data Added
 
@@ -25,6 +25,11 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 
 - The annotation colors have been changed to match the new backgrounds.
 - The App Store images have been updated to reflect autosuggest data based on Wikipedia.
+
+### ♻️ Code Refactoring
+
+- Boolean states for commands were converted into a single enum to make keyboard states much simpler to work with.
+- Code was refactored to work with the new enum style of command state management.
 
 # Scribe-iOS 1.4.0
 

--- a/Keyboards/KeyboardsBase/InterfaceVariables.swift
+++ b/Keyboards/KeyboardsBase/InterfaceVariables.swift
@@ -48,10 +48,22 @@ enum ShiftButtonState {
   case caps
 }
 
+/// States of the keyboard corresponding to which commands the user is executing.
+enum CommandState {
+  case idle
+  case select
+  case translate
+  case conjugate
+  case selectConjugation
+  case plural
+  case alreadyPlural
+  case invalid
+}
+
 // Baseline state variables.
 var keyboardState: KeyboardState = .letters
 var shiftButtonState: ShiftButtonState = .normal
-var scribeKeyState: Bool = false
+var commandState: CommandState = .idle
 
 // Variables and functions to determine display parameters.
 struct DeviceType {
@@ -112,7 +124,7 @@ func setKeyboard() {
 
 /// Sets the keyboard layouts given the chosen keyboard and device type.
 func setKeyboardLayout() {
-  if switchInput {
+  if commandState == .translate {
     setENKeyboardLayout()
   } else {
     let setLayoutFxn: () -> Void = keyboardLayoutDict[controllerLanguage]!
@@ -278,5 +290,5 @@ func setENKeyboardLayout() {
   pluralPromptAndPlaceholder = pluralPromptAndCursor + " " + pluralPlaceholder
   pluralPromptAndColorPlaceholder = NSMutableAttributedString(string: pluralPromptAndPlaceholder)
   pluralPromptAndColorPlaceholder.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
-  isAlreadyPluralMessage = "Already plural"
+  alreadyPluralMsg = "Already plural"
 }

--- a/Keyboards/KeyboardsBase/KeyboardKeys.swift
+++ b/Keyboards/KeyboardsBase/KeyboardKeys.swift
@@ -195,7 +195,7 @@ class KeyboardKey: UIButton {
       // Cancel Russian keyboard key resizing if translating as the keyboard is English.
       if controllerLanguage == "Russian"
         && keyboardState == .letters
-        && switchInput != true {
+        && commandState != .translate {
         self.layer.setValue(true, forKey: "isSpecial")
         self.widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1).isActive = true
       } else {
@@ -238,7 +238,7 @@ class KeyboardKey: UIButton {
       || self.key == "return"
       || self.key == "hideKeyboard" {
       if self.key == "return"
-          && ( controllerLanguage == "Portuguese" || controllerLanguage == "Italian" || switchInput == true )
+          && ( controllerLanguage == "Portuguese" || controllerLanguage == "Italian" || commandState == .translate )
           && self.row == 1
           && DeviceType.isPad {
         self.layer.setValue(true, forKey: "isSpecial")
@@ -273,7 +273,7 @@ class KeyboardKey: UIButton {
       } else {
         self.backgroundColor = specialKeyColor
       }
-    } else if self.key == "return" && commandState == true {
+    } else if self.key == "return" && [.translate, .conjugate, .plural].contains(commandState) {
       // Color the return key depending on if it's being used as enter for commands.
       self.backgroundColor = commandKeyColor
     } else if isSpecial == true {

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Annotate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Annotate.swift
@@ -46,7 +46,7 @@ func hideAnnotations(annotationDisplay: [UILabel]) {
 func setNounAnnotation(label: UILabel, annotation: String) {
   var annotationToDisplay: String = annotation
 
-  if scribeKeyState != true { // Cancel if typing while commands are displayed.
+  if ![.translate, .conjugate, .plural].contains(commandState) { // Cancel if typing while commands are displayed.
     // Convert annotation into the keyboard language if necessary.
     if nounAnnotationConversionDict[controllerLanguage] != nil {
       if nounAnnotationConversionDict[controllerLanguage]?[annotation] != nil {
@@ -141,7 +141,7 @@ func nounAnnotation(
         count: ( numberOfAnnotations * 7 ) - ( numberOfAnnotations - 1 )
       )
 
-      if invalidState != true {
+      if ![.alreadyPlural, .invalid].contains(commandState) {
         if DeviceType.isPhone {
           if commandPromptSpacing.count + wordSpacing.count > 9 {
             annotationDisplayWord = givenWord.prefix(2) + "..."
@@ -221,7 +221,7 @@ func typedNounAnnotation(
 func setPrepAnnotation(label: UILabel, annotation: String) {
   var annotationToDisplay: String = annotation
 
-  if scribeKeyState != true {
+  if commandState == .idle {
     // Convert annotation into the keyboard language if necessary.
     if caseAnnotationConversionDict[controllerLanguage] != nil {
       if caseAnnotationConversionDict[controllerLanguage]?[annotation] != nil {

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
@@ -85,13 +85,13 @@ class CommandBar: UILabel {
 
   // Changes the command bar text to an attributed string with a placeholder if there is no entered characters.
   func conditionallyAddPlaceholder() {
-    if commandState == true {
+    if [.translate, .conjugate, .plural].contains(commandState) {
       // self.text check required as attributed text changes to text when shiftButtonState == .shift.
-      if getTranslation == true && (self.text == translatePromptAndCursor || self.text == translatePromptAndPlaceholder) {
+      if commandState == .translate && (self.text == translatePromptAndCursor || self.text == translatePromptAndPlaceholder) {
         self.attributedText = colorizePrompt(for: translatePromptAndPlaceholder)
-      } else if getConjugation == true && (self.text == conjugatePromptAndCursor || self.text == conjugatePromptAndPlaceholder) {
+      } else if commandState == .conjugate && (self.text == conjugatePromptAndCursor || self.text == conjugatePromptAndPlaceholder) {
         self.attributedText = colorizePrompt(for: conjugatePromptAndPlaceholder)
-      } else if getPlural == true && (self.text == pluralPromptAndCursor || self.text == pluralPromptAndPlaceholder) {
+      } else if commandState == .plural && (self.text == pluralPromptAndCursor || self.text == pluralPromptAndPlaceholder) {
         self.attributedText = colorizePrompt(for: pluralPromptAndPlaceholder)
       }
     }
@@ -100,11 +100,11 @@ class CommandBar: UILabel {
   // Changes the color of the placeholder text to indicate that it is temporary.
   func colorizePrompt(for prompt: String) -> NSMutableAttributedString {
     let colorPrompt = NSMutableAttributedString(string: prompt)
-    if getTranslation == true {
+    if commandState == .translate {
       colorPrompt.setColorForText(textForAttribute: translatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
-    } else if getConjugation == true {
+    } else if commandState == .conjugate {
       colorPrompt.setColorForText(textForAttribute: conjugatePlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
-    } else if getPlural == true {
+    } else if commandState == .plural {
       colorPrompt.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
     }
 

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
@@ -31,12 +31,10 @@ var completionWords = [String]()
 // A larger vertical bar than the normal | key for the cursor.
 let commandCursor: String = "│"
 var commandPromptSpacing: String = ""
-var commandState: Bool = false
 
 // Command input and output variables.
 var inputWordIsCapitalized: Bool = false
 var wordToReturn: String = ""
-var invalidState: Bool = false
 var invalidCommandMsg: String = ""
 
 // Annotation variables.
@@ -45,10 +43,6 @@ var nounAnnotationsToDisplay: Int = 0
 var prepAnnotationState: Bool = false
 var annotationHeight = CGFloat(0)
 var annotationDisplayWord: String = ""
-
-// Indicates that the keyboard has switched to another input language.
-// For example another input method is needed to translate.
-var switchInput: Bool = false
 
 // Prompts and saving groups of languages.
 var allPrompts: [String] = [""]
@@ -64,7 +58,6 @@ var translatePlaceholder: String = ""
 var translatePromptAndCursor: String = ""
 var translatePromptAndPlaceholder: String = ""
 var translatePromptAndColorPlaceholder = NSMutableAttributedString()
-var getTranslation: Bool = false
 var wordToTranslate: String = ""
 
 // MARK: Conjugate Variables
@@ -74,8 +67,6 @@ var conjugatePlaceholder: String = ""
 var conjugatePromptAndCursor: String = ""
 var conjugatePromptAndPlaceholder: String = ""
 var conjugatePromptAndColorPlaceholder = NSMutableAttributedString()
-var getConjugation: Bool = false
-var conjugateView: Bool = false
 var conjugateAlternateView: Bool = false
 
 var allTenses = [String]()
@@ -117,6 +108,4 @@ var pluralPlaceholder: String = ""
 var pluralPromptAndCursor: String = ""
 var pluralPromptAndPlaceholder: String = ""
 var pluralPromptAndColorPlaceholder = NSMutableAttributedString()
-var getPlural: Bool = false
-var isAlreadyPluralState: Bool = false
-var isAlreadyPluralMessage: String = ""
+var alreadyPluralMsg: String = ""

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
@@ -45,14 +45,13 @@ let keyboardConjLabelDict: [String: Any] = [
 ///   - commandBar: the command bar into which an input was entered.
 func triggerConjugation(commandBar: UILabel) -> Bool {
   // Cancel via a return press.
-  if commandBar.text! == conjugatePromptAndCursor {
+  if commandBar.text! == conjugatePromptAndCursor || commandBar.text! == conjugatePromptAndPlaceholder {
     return false
   }
   verbToConjugate = (commandBar.text!.substring(with: conjugatePrompt.count..<(commandBar.text!.count) - 1))
   verbToConjugate = String(verbToConjugate.trailingSpacesTrimmed)
 
   // Check to see if the input was uppercase to return an uppercase conjugation.
-  inputWordIsCapitalized = false
   let firstLetter = verbToConjugate.substring(toIdx: 1)
   inputWordIsCapitalized = firstLetter.isUppercase
   verbToConjugate = verbToConjugate.lowercased()
@@ -88,6 +87,5 @@ func returnConjugation(keyPressed: UIButton, requestedTense: String) {
       proxy.insertText(wordToReturn + " ")
     }
   }
-  commandState = false
-  conjugateView = false
+  commandState = .idle
 }

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Plural.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Plural.swift
@@ -12,7 +12,7 @@ import UIKit
 ///   - commandBar: the command bar into which an input was entered.
 func queryPlural(commandBar: UILabel) {
   // Cancel via a return press.
-  if commandBar.text! == pluralPromptAndCursor {
+  if commandBar.text! == pluralPromptAndCursor || commandBar.text! == pluralPromptAndPlaceholder {
     return
   }
   var noun: String = (commandBar.text!.substring(
@@ -38,11 +38,9 @@ func queryPlural(commandBar: UILabel) {
       }
     } else {
       proxy.insertText(noun + " ")
-      commandBar.text = commandPromptSpacing + isAlreadyPluralMessage
-      invalidState = true
-      isAlreadyPluralState = true
+      commandState = .alreadyPlural
     }
   } else {
-    invalidState = true
+    commandState = .invalid
   }
 }

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
@@ -12,7 +12,7 @@ import UIKit
 ///   - commandBar: the command bar into which an input was entered.
 func queryTranslation(commandBar: UILabel) {
   // Cancel via a return press.
-  if commandBar.text! == translatePromptAndCursor {
+  if commandBar.text! == translatePromptAndCursor || commandBar.text! == translatePromptAndPlaceholder {
     return
   }
   wordToTranslate = (commandBar.text!.substring(
@@ -35,6 +35,6 @@ func queryTranslation(commandBar: UILabel) {
       proxy.insertText(wordToReturn + " ")
     }
   } else {
-    invalidState = true
+    commandState = .invalid
   }
 }

--- a/Keyboards/LanguageKeyboards/French/FRInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FRInterfaceVariables.swift
@@ -133,5 +133,5 @@ func setFRKeyboardLayout() {
   pluralPromptAndPlaceholder = pluralPromptAndCursor + " " + pluralPlaceholder
   pluralPromptAndColorPlaceholder = NSMutableAttributedString(string: pluralPromptAndPlaceholder)
   pluralPromptAndColorPlaceholder.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
-  isAlreadyPluralMessage = "Déjà pluriel"
+  alreadyPluralMsg = "Déjà pluriel"
 }

--- a/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
@@ -139,5 +139,5 @@ func setDEKeyboardLayout() {
   pluralPromptAndPlaceholder = pluralPromptAndCursor + " " + pluralPlaceholder
   pluralPromptAndColorPlaceholder = NSMutableAttributedString(string: pluralPromptAndPlaceholder)
   pluralPromptAndColorPlaceholder.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
-  isAlreadyPluralMessage = "Schon Plural"
+  alreadyPluralMsg = "Schon Plural"
 }

--- a/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
@@ -133,5 +133,5 @@ func setITKeyboardLayout() {
   pluralPromptAndPlaceholder = pluralPromptAndCursor + " " + pluralPlaceholder
   pluralPromptAndColorPlaceholder = NSMutableAttributedString(string: pluralPromptAndPlaceholder)
   pluralPromptAndColorPlaceholder.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
-  isAlreadyPluralMessage = "Già plurale"
+  alreadyPluralMsg = "Già plurale"
 }

--- a/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
@@ -131,5 +131,5 @@ func setPTKeyboardLayout() {
   pluralPromptAndPlaceholder = pluralPromptAndCursor + " " + pluralPlaceholder
   pluralPromptAndColorPlaceholder = NSMutableAttributedString(string: pluralPromptAndPlaceholder)
   pluralPromptAndColorPlaceholder.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
-  isAlreadyPluralMessage = "Já plural"
+  alreadyPluralMsg = "Já plural"
 }

--- a/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
@@ -121,5 +121,5 @@ func setRUKeyboardLayout() {
   pluralPromptAndPlaceholder = pluralPromptAndCursor + " " + pluralPlaceholder
   pluralPromptAndColorPlaceholder = NSMutableAttributedString(string: pluralPromptAndPlaceholder)
   pluralPromptAndColorPlaceholder.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
-  isAlreadyPluralMessage = "Уже во множ"
+  alreadyPluralMsg = "Уже во множ"
 }

--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -135,5 +135,5 @@ func setESKeyboardLayout() {
   pluralPromptAndPlaceholder = pluralPromptAndCursor + " " + pluralPlaceholder
   pluralPromptAndColorPlaceholder = NSMutableAttributedString(string: pluralPromptAndPlaceholder)
   pluralPromptAndColorPlaceholder.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
-  isAlreadyPluralMessage = "Ya en plural"
+  alreadyPluralMsg = "Ya en plural"
 }

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -137,5 +137,5 @@ func setSVKeyboardLayout() {
   pluralPromptAndPlaceholder = pluralPromptAndCursor + " " + pluralPlaceholder
   pluralPromptAndColorPlaceholder = NSMutableAttributedString(string: pluralPromptAndPlaceholder)
   pluralPromptAndColorPlaceholder.setColorForText(textForAttribute: pluralPlaceholder, withColor: UIColor(cgColor: commandBarBorderColor))
-  isAlreadyPluralMessage = "Redan plural"
+  alreadyPluralMsg = "Redan plural"
 }


### PR DESCRIPTION
@SaurabhJamadagni, soooooooo here this is 😊

I hope this makes our lives much easier :) You'll see that there are more deletions than additions in this one 🚀 

There are lots of little changes in here:
- I renamed `isAlreadyPluralMessage` to `alreadyPluralMsg`, so disregard all those files
- Changes `commandState` to an `enum` as we discussed
- Updated the codes to work with the new version of it
    - This included a ton of work in the main view controller
    - I reordered lots of things so that we're accounting for all the variations of `commandState`

What this fixes:
- Hopefully the road ahead is a lot easier :)
- Fixes issues where the annotations were showing up on top of the invalid message (so translate something like `fdsjkal`, or use the plural command on something that already is plural)
    - Trying to fix this and finally realizing how much I hate all the booleans was the source of all this :) 
- Changes the interface for invalid messages so that it's the command bar and Scribe key next to each other (just like it used to be 🥲)
    - Reason for this is that I figured the proper user flow is that they get an invalid message, they see it, and they can either start typing - which resets the keyboard - or they can jump into the command again