### PR TITLE
#188 #194 autocomplete bug fix and autosuggest placeholders

### DIFF
--- a/Keyboards/KeyboardsBase/Extensions.swift
+++ b/Keyboards/KeyboardsBase/Extensions.swift
@@ -55,13 +55,17 @@ extension String {
     return self == self.uppercased()
   }
 
+  var isCaptalized: Bool {
+    return self == prefix(1).uppercased() + self.lowercased().dropFirst()
+  }
+
   func count(of char: Character) -> Int {
     return reduce(0) {
       $1 == char ? $0 + 1 : $0
     }
   }
   
-  func capitalizingFirstLetter() -> String {
+  func capitalize() -> String {
     return prefix(1).uppercased() + self.lowercased().dropFirst()
   }
 }

--- a/Keyboards/KeyboardsBase/InterfaceVariables.swift
+++ b/Keyboards/KeyboardsBase/InterfaceVariables.swift
@@ -60,10 +60,17 @@ enum CommandState {
   case invalid
 }
 
+/// States of the keyboard corresponding to which auto actions should be presented.
+enum AutoActionState {
+  case complete
+  case suggest
+}
+
 // Baseline state variables.
 var keyboardState: KeyboardState = .letters
 var shiftButtonState: ShiftButtonState = .normal
 var commandState: CommandState = .idle
+var autoActionState: AutoActionState = .suggest
 
 // Variables and functions to determine display parameters.
 struct DeviceType {
@@ -269,6 +276,7 @@ func setENKeyboardLayout() {
   currencySymbolAlternates = dollarAlternateKeys
   spaceBar = "space"
   invalidCommandMsg = "Not in Wikidata"
+  baseAutosuggestions = ["I", "I'm", "we"]
 
   translateKeyLbl = "Translate"
   translatePrompt = commandPromptSpacing + "en -› \(getControllerLanguageAbbr()): "

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
@@ -21,7 +21,8 @@ let prepositions = loadJSONToDict(filename: "prepositions")
 // Words that should not be included in autocomplete should be added to the string below.
 let autocompleteWords = nouns!.keys.filter(
   { $0.rangeOfCharacter(from: CharacterSet(charactersIn: "1234567890-")) == nil }
-).sorted()
+).sorted{$0.caseInsensitiveCompare($1) == .orderedAscending}
+var baseAutosuggestions = [String]()
 
 var currentPrefix: String = ""
 var pastStringInTextProxy: String = ""

--- a/Keyboards/LanguageKeyboards/French/FRInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FRInterfaceVariables.swift
@@ -109,6 +109,7 @@ func setFRKeyboardLayout() {
   currencySymbolAlternates = euroAlternateKeys
   spaceBar = "espace"
   invalidCommandMsg = "Pas dans Wikidata"
+  baseAutosuggestions = ["je", "il", "le"]
 
   translateKeyLbl = "Traduire"
   translatePlaceholder = "Entrez un mot"

--- a/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
@@ -115,6 +115,7 @@ func setDEKeyboardLayout() {
   currencySymbolAlternates = euroAlternateKeys
   spaceBar = "Leerzeichen"
   invalidCommandMsg = "Nicht in Wikidata"
+  baseAutosuggestions = ["ich", "die", "das"]
 
   translateKeyLbl = "Übersetzen"
   translatePlaceholder = "Wort eingeben"

--- a/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
@@ -109,6 +109,7 @@ func setITKeyboardLayout() {
   currencySymbolAlternates = euroAlternateKeys
   spaceBar = "spazio"
   invalidCommandMsg = "Non in Wikidata"
+  baseAutosuggestions = ["ho", "non", "ma"]
 
   translateKeyLbl = "Tradurre"
   translatePlaceholder = "Inserisci una parola"

--- a/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
@@ -107,6 +107,7 @@ func setPTKeyboardLayout() {
   currencySymbolAlternates = dollarAlternateKeys
   spaceBar = "espaço"
   invalidCommandMsg = "Não está no Wikidata"
+  baseAutosuggestions = ["o", "a", "eu"]
 
   translateKeyLbl = "Traduzir"
   translatePlaceholder = "Digite uma palavra"

--- a/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
@@ -97,6 +97,7 @@ func setRUKeyboardLayout() {
   currencySymbolAlternates = roubleAlternateKeys
   spaceBar = "Пробел"
   invalidCommandMsg = "Нет в Викиданных"
+  baseAutosuggestions = ["я", "а", "в"]
 
   translateKeyLbl = "Перевести"
   translatePlaceholder = "Введите слово"

--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -111,6 +111,7 @@ func setESKeyboardLayout() {
   currencySymbolAlternates = dollarAlternateKeys
   spaceBar = "espacio"
   invalidCommandMsg = "No en Wikidata"
+  baseAutosuggestions = ["el", "la", "no"]
 
   translateKeyLbl = "Traducir"
   translatePlaceholder = "Ingrese una palabra"

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -113,6 +113,7 @@ func setSVKeyboardLayout() {
   currencySymbolAlternates = kronaAlternateKeys
   spaceBar = "mellanslag"
   invalidCommandMsg = "Inte i Wikidata"
+  baseAutosuggestions = ["jag", "det", "men"]
 
   translateKeyLbl = "Översätt"
   translatePlaceholder = "Ange ett ord"


### PR DESCRIPTION
Alright, @SaurabhJamadagni, this is a lot more minor improvements to fix the bug where autocomplete wasn't being triggered after a command was used. I got carried away a bit again though 😊

What's included:
- The aforementioned bugfix
- Added an emum `AutoActionState` that determines if we're completing or suggesting
    - I made a boolean at first and was like, "Waaaaaait a minute..... 😅"
- Fixed the sorting of the words for autocomplete so that it's done regardless of case
- Fixed the conditionals within autocomplete as we need to be able to type a lowercase word but get an uppercase/caps suggestion such as `germany -> Germany`
- Added variables for the first three words that appear whenever you load a system version of one of the Scribe languages that can serve as our default autosuggestions (replaced your function with them as you directed)
- Set up a trigger within `conditionallySetAutoActionBtns` to determine which kind of action is being done
- Went through and defined what type of action should follow each kind of key press (spaces -> autosuggest, normal keys -> autocomplete, etc)

Let me know what you think on all this! Just am trying to get the work load down a bit for the both of us. Would be great if you could check out the last bugs in #188 related to deletion :) After that it's on to autosuggest 😊