### PR TITLE
#188 fix to delete crash + minor template change

### DIFF
--- a/.github/ISSUE_TEMPLATE/data_wikidata.yml
+++ b/.github/ISSUE_TEMPLATE/data_wikidata.yml
@@ -19,9 +19,9 @@ body:
     validations:
       required: true
   - type: textarea
-    id: choice
+    id: description
     attributes:
-      label: Issue
+      label: Description
       placeholder: Let us know what your idea is!
     validations:
       required: true


### PR DESCRIPTION
@SaurabhJamadagni, I think this is what we need to close #188 😊 I think that most of the problems were coming from `changePastTextsFromProxy`. The command prompt crash on delete was happening because we weren't checking to make sure that we weren't in a command within this function. Beyond this, I saw that the crash when the cursor is at the start of the proxy also stopped happening when I removed this function and it's call within `handleDeleteButtonPressed`. It seems that everything is working without this function, so could you just check all this and see if I'm removing it by accident? Autocomplete is updating as the user deletes, so maybe something in how the new `CommandState` enum is functioning fixed a bug that made this function not necessary anymore?