### PR TITLE
Adding Autosuggestions function

### DIFF
--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -282,10 +282,44 @@ class KeyboardViewController: UIInputViewController {
     ]
     
     let prefix = pastStringInTextProxy.replacingOccurrences(of: secondaryPastStringOnDelete, with: "").replacingOccurrences(of: " ", with: "")
-    if dummySuggestions.keys.contains(prefix) {
-      completionWords = dummySuggestions[prefix] ?? [String]()
-    }
-    if completionWords.isEmpty {
+    
+    /// We have to consider these different cases as the key always has to match.
+    /// Else, even if the lowercased prefix is present in the dictionary, if the actual prefix isn't present we won't get an output.
+    if dummySuggestions.keys.contains(prefix.lowercased()) {
+      if let suggestions = dummySuggestions[prefix.lowercased()] {
+        completionWords = [String]()
+        var i = 0
+        while i < 3 {
+          if shiftButtonState == .shift {
+            completionWords.append(suggestions[i].capitalize())
+          } else if shiftButtonState == .caps {
+            completionWords.append(suggestions[i].uppercased())
+          } else {
+            completionWords.append(suggestions[i])
+          }
+          i += 1
+        }
+      } else {
+        getDefaultAutosuggestions()
+      }
+    } else if dummySuggestions.keys.contains(prefix.capitalize()) {
+      if let suggestions = dummySuggestions[prefix.capitalize()] {
+        completionWords = [String]()
+        var i = 0
+        while i < 3 {
+          if shiftButtonState == .shift {
+            completionWords.append(suggestions[i].capitalize())
+          } else if shiftButtonState == .caps {
+            completionWords.append(suggestions[i].uppercased())
+          } else {
+            completionWords.append(suggestions[i])
+          }
+          i += 1
+        }
+      } else {
+        getDefaultAutosuggestions()
+      }
+    } else {
       getDefaultAutosuggestions()
     }
   }

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -274,12 +274,26 @@ class KeyboardViewController: UIInputViewController {
   }
 
   /// Generates an array of the three autosuggest words.
-  func getAutosuggestions() {}
+  func getAutosuggestions() {
+    let dummySuggestions = [
+      "Buch": ["lesen", "kaufen", "schenken"],
+      "ich": ["habe", "bin", "kann"],
+      "mit": ["mir", "dir", "ihr"]
+    ]
+    
+    let prefix = pastStringInTextProxy.replacingOccurrences(of: secondaryPastStringOnDelete, with: "").replacingOccurrences(of: " ", with: "")
+    if dummySuggestions.keys.contains(prefix) {
+      completionWords = dummySuggestions[prefix] ?? [String]()
+    }
+    if completionWords.isEmpty {
+      getDefaultAutosuggestions()
+    }
+  }
 
   /// Sets up command buttons to execute autocomplete and autosuggest.
   func conditionallySetAutoActionBtns() {
     if autoActionState == .suggest {
-      getDefaultAutosuggestions()
+      getAutosuggestions()
     } else {
       getAutocompletions()
     }
@@ -295,11 +309,11 @@ class KeyboardViewController: UIInputViewController {
       }
 
       setBtn(btn: conjugateKey, color: keyboardBgColor, name: "AutoAction2", canCap: false, isSpecial: false)
-      styleBtn(btn: conjugateKey, title: completionWords[1], radius: commandKeyCornerRadius)
+      styleBtn(btn: conjugateKey, title: !autoAction1Visible ? completionWords[0] : completionWords[1], radius: commandKeyCornerRadius)
       activateBtn(btn: conjugateKey)
 
       setBtn(btn: pluralKey, color: keyboardBgColor, name: "AutoAction3", canCap: false, isSpecial: false)
-      styleBtn(btn: pluralKey, title: completionWords[2], radius: commandKeyCornerRadius)
+      styleBtn(btn: pluralKey, title: !autoAction1Visible ? completionWords[1] : completionWords[2], radius: commandKeyCornerRadius)
       activateBtn(btn: pluralKey)
 
       translateKey.layer.shadowColor = UIColor.clear.cgColor


### PR DESCRIPTION
- PR for issue #194 
- Adds body to `getAutosuggestions` function.
- Shifts suggestions a place to the left if annotations are active.

Hey @andrewtavis! Could you please review these changes. The function may look like it has repetitive code inside it but without it, it was not accepting input in different cases. For example, if the key "ich" was typed as "Ich", we could see that the key is present in the dictionary by comparing the lowercased strings. But what would happen is that when retrieving elements, "Ich" would be a wrong key as the correct key is "ich".

I think the two different cases I have considered work with all the permutations that are possible -- key lowercase and input uppercase OR key uppercase and input uppercase and so on. I hope that works. If you find a way I could simplify this further let me know. I would be glad to make the changes :)