### PR TITLE
Switch delete button when pressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 
 - The annotation colors have been changed to match the new backgrounds.
 - The App Store images have been updated to reflect autosuggest data based on Wikipedia.
+- Delete key features pressed state style similar to the native keyboard
 
 ### ♻️ Code Refactoring
 

--- a/Keyboards/KeyboardsBase/KeyboardStyling.swift
+++ b/Keyboards/KeyboardsBase/KeyboardStyling.swift
@@ -126,6 +126,15 @@ func styleIconBtn(btn: UIButton, color: UIColor, iconName: String) {
   btn.tintColor = color
 }
 
+/// Sets icon of delete button for pressed or non-pressed state.
+/// - Parameters:
+///   - button: The delete button.
+///   - isPressed: Determines if icon for pressed or non-pressed state will be set.
+func styleDeleteButton(_ button: UIButton, isPressed: Bool) {
+  styleIconBtn(btn: button, color: keyCharColor,
+               iconName: isPressed ? "delete.left.fill" : "delete.left")
+}
+
 /// Adds padding to keys to position them.
 ///
 /// - Parameters

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -1459,6 +1459,7 @@ class KeyboardViewController: UIInputViewController {
       executeAutoAction(keyPressed: pluralKey)
 
     case "delete":
+      styleDeleteButton(sender, isPressed: false)
       if ![.translate, .conjugate, .plural].contains(commandState) {
         // Control shift state on delete.
         if keyboardState == .letters && shiftButtonState == .shift && proxy.documentContextBeforeInput != nil {
@@ -1616,6 +1617,9 @@ class KeyboardViewController: UIInputViewController {
   ///   - sender: the key that was pressed.
   @objc func keyTouchDown(_ sender: UIButton) {
     sender.backgroundColor = keyPressedColor
+    if (sender as? KeyboardKey)?.key == "delete" {
+      styleDeleteButton(sender, isPressed: true)
+    }
   }
 
   /// Defines events that occur given multiple presses of a single key.
@@ -1692,7 +1696,10 @@ class KeyboardViewController: UIInputViewController {
     } else if gesture.state == .ended || gesture.state == .cancelled {
       backspaceTimer?.invalidate()
       backspaceTimer = nil
-      (gesture.view as! UIButton).backgroundColor = specialKeyColor
+      if let button = gesture.view as? UIButton {
+        button.backgroundColor = specialKeyColor
+        styleDeleteButton(button, isPressed: false)
+      }
     }
   }
 


### PR DESCRIPTION
### What does it do
- adds method for styling delete button
- changes delete button's style when pressing similar to native delete button
- see video of the feature attached here: https://github.com/scribe-org/Scribe-iOS/issues/204#issuecomment-1260087859