### PR TITLE
Disable Conjugation View Shift buttons conditionally

### DIFF
--- a/Keyboards/KeyboardsBase/InterfaceVariables.swift
+++ b/Keyboards/KeyboardsBase/InterfaceVariables.swift
@@ -70,11 +70,20 @@ enum AutoActionState {
   case suggest
 }
 
+/// States for which conjugation table view shift button should be active.
+enum ConjViewShiftButtonsState {
+  case bothActive
+  case bothInactive
+  case leftInactive
+  case rightInactive
+}
+
 // Baseline state variables.
 var keyboardState: KeyboardState = .letters
 var shiftButtonState: ShiftButtonState = .normal
 var commandState: CommandState = .idle
 var autoActionState: AutoActionState = .suggest
+var conjViewShiftButtonsState: ConjViewShiftButtonsState = .bothInactive
 
 // Variables and functions to determine display parameters.
 struct DeviceType {

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -772,8 +772,14 @@ class KeyboardViewController: UIInputViewController {
       isSpecial: false
     )
 
-    activateBtn(btn: shiftFormsDisplayLeft)
-    activateBtn(btn: shiftFormsDisplayRight)
+    if [.bothActive, .rightInactive].contains(conjViewShiftButtonsState) {
+      activateBtn(btn: shiftFormsDisplayLeft)
+    } else {
+      deactivateBtn(btn: shiftFormsDisplayLeft)
+    }
+    if [.bothActive, .leftInactive].contains(conjViewShiftButtonsState) {
+      activateBtn(btn: shiftFormsDisplayRight)
+    } else { deactivateBtn(btn: shiftFormsDisplayRight)}
 
     // Make all labels clear and set their font for if they will be used.
     let allFormDisplayLabels: [UIButton] =
@@ -794,8 +800,14 @@ class KeyboardViewController: UIInputViewController {
 
   /// Activates all buttons that are associated with the conjugation display.
   func activateConjugationDisplay() {
-    activateBtn(btn: shiftFormsDisplayLeft)
-    activateBtn(btn: shiftFormsDisplayRight)
+    if [.bothActive, .rightInactive].contains(conjViewShiftButtonsState) {
+      activateBtn(btn: shiftFormsDisplayLeft)
+    } else {
+      deactivateBtn(btn: shiftFormsDisplayLeft)
+    }
+    if [.bothActive, .leftInactive].contains(conjViewShiftButtonsState) {
+      activateBtn(btn: shiftFormsDisplayRight)
+    } else { deactivateBtn(btn: shiftFormsDisplayRight)}
 
     switch formsDisplayDimensions {
     case .view3x2:
@@ -1461,9 +1473,13 @@ class KeyboardViewController: UIInputViewController {
 
       activateConjugationDisplay()
       styleBtn(btn: shiftFormsDisplayLeft, title: "", radius: keyCornerRadius)
-      styleIconBtn(btn: shiftFormsDisplayLeft, color: keyCharColor, iconName: "chevron.left")
+      styleIconBtn(btn: shiftFormsDisplayLeft,
+                   color: ![.bothInactive, .leftInactive].contains(conjViewShiftButtonsState) ? keyCharColor : specialKeyColor,
+                   iconName: "chevron.left")
       styleBtn(btn: shiftFormsDisplayRight, title: "", radius: keyCornerRadius)
-      styleIconBtn(btn: shiftFormsDisplayRight, color: keyCharColor, iconName: "chevron.right")
+      styleIconBtn(btn: shiftFormsDisplayRight,
+                   color: ![.bothInactive, .rightInactive].contains(conjViewShiftButtonsState) ? keyCharColor : specialKeyColor,
+                   iconName: "chevron.right")
 
       if commandState == .selectVerbConjugation {
         setVerbConjugationState()
@@ -1681,16 +1697,19 @@ class KeyboardViewController: UIInputViewController {
       for i in 0..<annotationBtns.count {
         annotationBtns[i].backgroundColor = annotationColors[i]
       }
-      let wordsTyped = proxy.documentContextBeforeInput!.components(separatedBy: " ")
-      let lastWordTyped = wordsTyped.secondToLast()
-      var wordToCheck: String = ""
-      if !languagesWithCapitalizedNouns.contains(controllerLanguage) {
-        wordToCheck = lastWordTyped!.lowercased()
+      
+      if let wordSelected = proxy.selectedText {
+        wordToCheck = wordSelected
       } else {
-        wordToCheck = lastWordTyped!
+        wordsTyped = proxy.documentContextBeforeInput!.components(separatedBy: " ")
+        let lastWordTyped = wordsTyped.secondToLast()
+        if !languagesWithCapitalizedNouns.contains(controllerLanguage) {
+          wordToCheck = lastWordTyped!.lowercased()
+        } else {
+          wordToCheck = lastWordTyped!
+        }
       }
-
-      let isPrep = prepositions?[wordToCheck.lowercased()] != nil
+      isPrep = prepositions?[wordToCheck.lowercased()] != nil
       if isPrep {
         resetCaseDeclensionState()
         commandState = .selectCaseDeclension

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
@@ -269,14 +269,19 @@ func resetCaseDeclensionState() {
     }
   } else if controllerLanguage == "Russian" {
     if prepAnnotationForm.contains("Acc") {
+      conjViewShiftButtonsState = .leftInactive
       ruCaseDeclensionState = .accusative
     } else if prepAnnotationForm.contains("Dat") {
+      conjViewShiftButtonsState = .bothActive
       ruCaseDeclensionState = .dative
     } else if prepAnnotationForm.contains("Gen") {
+      conjViewShiftButtonsState = .bothActive
       ruCaseDeclensionState = .genitive
     } else if prepAnnotationForm.contains("Pre") {
+      conjViewShiftButtonsState = .rightInactive
       ruCaseDeclensionState = .prepositional
     } else {
+      conjViewShiftButtonsState = .bothActive
       ruCaseDeclensionState = .instrumental
     }
   }

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
@@ -230,10 +230,12 @@ func returnConjugation(keyPressed: UIButton, requestedForm: String) {
   }
   autoActionState = .suggest
   commandState = .idle
+  conjViewShiftButtonsState = .bothInactive
 }
 
 /// Returns the conjugation state to its initial conjugation based on the keyboard language.
 func resetVerbConjugationState() {
+  conjViewShiftButtonsState = .leftInactive
   if controllerLanguage == "French" {
     frConjugationState = .indicativePresent
   } else if controllerLanguage == "German" {
@@ -256,10 +258,13 @@ func resetCaseDeclensionState() {
   // The case conjugation display starts on the left most case.
   if controllerLanguage == "German" {
     if prepAnnotationForm.contains("Acc") {
+      conjViewShiftButtonsState = .leftInactive
       deCaseDeclensionState = .accusative
     } else if prepAnnotationForm.contains("Dat") {
+      conjViewShiftButtonsState = .bothActive
       deCaseDeclensionState = .dative
     } else {
+      conjViewShiftButtonsState = .bothActive
       deCaseDeclensionState = .genitive
     }
   } else if controllerLanguage == "Russian" {

--- a/Keyboards/LanguageKeyboards/French/FRCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FRCommandVariables.swift
@@ -62,8 +62,10 @@ func frConjugationStateLeft() {
   case .indicativePresent:
     break
   case .preterite:
+    conjViewShiftButtonsState = .leftInactive
     frConjugationState = .indicativePresent
   case .imperfect:
+    conjViewShiftButtonsState = .bothActive
     frConjugationState = .preterite
   }
 }
@@ -72,8 +74,10 @@ func frConjugationStateLeft() {
 func frConjugationStateRight() {
   switch frConjugationState {
   case .indicativePresent:
+    conjViewShiftButtonsState = .bothActive
     frConjugationState = .preterite
   case .preterite:
+    conjViewShiftButtonsState = .rightInactive
     frConjugationState = .imperfect
   case .imperfect:
     break

--- a/Keyboards/LanguageKeyboards/German/DECommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DECommandVariables.swift
@@ -442,29 +442,39 @@ func deConjugationStateLeft() {
     case .accusative:
       break
     case .accusativePersonal:
+      conjViewShiftButtonsState = .leftInactive
       deCaseDeclensionState = .accusative
     case .accusativePossesive:
+      conjViewShiftButtonsState = .bothActive
       deCaseDeclensionState = .accusativePersonal
     case .dative:
+      conjViewShiftButtonsState = .bothActive
       deCaseDeclensionState = .accusativePossesive
     case .dativePersonal:
+      conjViewShiftButtonsState = .bothActive
       deCaseDeclensionState = .dative
     case .dativePossesive:
+      conjViewShiftButtonsState = .bothActive
       deCaseDeclensionState = .dativePersonal
     case .genitive:
+      conjViewShiftButtonsState = .bothActive
       deCaseDeclensionState = .dativePossesive
     case .genitivePersonal:
+      conjViewShiftButtonsState = .bothActive
       deCaseDeclensionState = .genitive
     case .genitivePossesive:
       deCaseDeclensionState = .genitivePersonal
+      conjViewShiftButtonsState = .bothActive
     }
   } else {
     switch deConjugationState {
     case .indicativePresent:
       break
     case .indicativePreterite:
+      conjViewShiftButtonsState = .leftInactive
       deConjugationState = .indicativePresent
     case .indicativePerfect:
+      conjViewShiftButtonsState = .bothActive
       deConjugationState = .indicativePreterite
     }
   }
@@ -475,20 +485,28 @@ func deConjugationStateRight() {
   if commandState == .selectCaseDeclension && deCaseVariantDeclensionState == .disabled {
     switch deCaseDeclensionState {
     case .accusative:
+      conjViewShiftButtonsState = .bothActive
       deCaseDeclensionState = .accusativePersonal
     case .accusativePersonal:
+      conjViewShiftButtonsState = .bothActive
       deCaseDeclensionState = .accusativePossesive
     case .accusativePossesive:
+      conjViewShiftButtonsState = .bothActive
       deCaseDeclensionState = .dative
     case .dative:
+      conjViewShiftButtonsState = .bothActive
       deCaseDeclensionState = .dativePersonal
     case .dativePersonal:
+      conjViewShiftButtonsState = .bothActive
       deCaseDeclensionState = .dativePossesive
     case .dativePossesive:
+      conjViewShiftButtonsState = .bothActive
       deCaseDeclensionState = .genitive
     case .genitive:
+      conjViewShiftButtonsState = .bothActive
       deCaseDeclensionState = .genitivePersonal
     case .genitivePersonal:
+      conjViewShiftButtonsState = .rightInactive
       deCaseDeclensionState = .genitivePossesive
     case .genitivePossesive:
       break
@@ -496,8 +514,10 @@ func deConjugationStateRight() {
   } else {
     switch deConjugationState {
     case .indicativePresent:
+      conjViewShiftButtonsState = .bothActive
       deConjugationState = .indicativePreterite
     case .indicativePreterite:
+      conjViewShiftButtonsState = .rightInactive
       deConjugationState = .indicativePerfect
     case .indicativePerfect:
       break

--- a/Keyboards/LanguageKeyboards/Italian/ITCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITCommandVariables.swift
@@ -62,8 +62,10 @@ func itConjugationStateLeft() {
   case .present:
     break
   case .preterite:
+    conjViewShiftButtonsState = .leftInactive
     itConjugationState = .present
   case .imperfect:
+    conjViewShiftButtonsState = .bothActive
     itConjugationState = .preterite
   }
 }
@@ -72,8 +74,10 @@ func itConjugationStateLeft() {
 func itConjugationStateRight() {
   switch itConjugationState {
   case .present:
+    conjViewShiftButtonsState = .bothActive
     itConjugationState = .preterite
   case .preterite:
+    conjViewShiftButtonsState = .rightInactive
     itConjugationState = .imperfect
   case .imperfect:
     break

--- a/Keyboards/LanguageKeyboards/Portuguese/PTCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTCommandVariables.swift
@@ -67,10 +67,13 @@ func ptConjugationStateLeft() {
   case .indicativePresent:
     break
   case .pastPerfect:
+    conjViewShiftButtonsState = .leftInactive
     ptConjugationState = .indicativePresent
   case .pastImperfect:
+    conjViewShiftButtonsState = .bothActive
     ptConjugationState = .pastPerfect
   case .futureSimple:
+    conjViewShiftButtonsState = .bothActive
     ptConjugationState = .pastImperfect
   }
 }
@@ -79,10 +82,13 @@ func ptConjugationStateLeft() {
 func ptConjugationStateRight() {
   switch ptConjugationState {
   case .indicativePresent:
+    conjViewShiftButtonsState = .bothActive
     ptConjugationState = .pastPerfect
   case .pastPerfect:
+    conjViewShiftButtonsState = .bothActive
     ptConjugationState = .pastImperfect
   case .pastImperfect:
+    conjViewShiftButtonsState = .rightInactive
     ptConjugationState = .futureSimple
   case .futureSimple:
     break

--- a/Keyboards/LanguageKeyboards/Russian/RUCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUCommandVariables.swift
@@ -147,12 +147,16 @@ func ruConjugationStateLeft() {
     case .accusative:
       break
     case .dative:
+      conjViewShiftButtonsState = .leftInactive
       ruCaseDeclensionState = .accusative
     case .genitive:
+      conjViewShiftButtonsState = .bothActive
       ruCaseDeclensionState = .dative
     case .instrumental:
+      conjViewShiftButtonsState = .bothActive
       ruCaseDeclensionState = .genitive
     case .prepositional:
+      conjViewShiftButtonsState = .bothActive
       ruCaseDeclensionState = .instrumental
     }
   } else {
@@ -160,6 +164,7 @@ func ruConjugationStateLeft() {
     case .present:
       break
     case .past:
+      conjViewShiftButtonsState = .leftInactive
       ruConjugationState = .present
     }
   }
@@ -170,12 +175,16 @@ func ruConjugationStateRight() {
   if commandState == .selectCaseDeclension {
     switch ruCaseDeclensionState {
     case .accusative:
+      conjViewShiftButtonsState = .bothActive
       ruCaseDeclensionState = .dative
     case .dative:
+      conjViewShiftButtonsState = .bothActive
       ruCaseDeclensionState = .genitive
     case .genitive:
+      conjViewShiftButtonsState = .bothActive
       ruCaseDeclensionState = .instrumental
     case .instrumental:
+      conjViewShiftButtonsState = .rightInactive
       ruCaseDeclensionState = .prepositional
     case .prepositional:
       break
@@ -183,6 +192,7 @@ func ruConjugationStateRight() {
   } else {
     switch ruConjugationState {
     case .present:
+      conjViewShiftButtonsState = .rightInactive
       ruConjugationState = .past
     case .past:
       break

--- a/Keyboards/LanguageKeyboards/Spanish/ESCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESCommandVariables.swift
@@ -62,8 +62,10 @@ func esConjugationStateLeft() {
   case .indicativePresent:
     break
   case .preterite:
+    conjViewShiftButtonsState = .leftInactive
     esConjugationState = .indicativePresent
   case .imperfect:
+    conjViewShiftButtonsState = .bothActive
     esConjugationState = .preterite
   }
 }
@@ -72,8 +74,10 @@ func esConjugationStateLeft() {
 func esConjugationStateRight() {
   switch esConjugationState {
   case .indicativePresent:
+    conjViewShiftButtonsState = .bothActive
     esConjugationState = .preterite
   case .preterite:
+    conjViewShiftButtonsState = .rightInactive
     esConjugationState = .imperfect
   case .imperfect:
     break

--- a/Keyboards/LanguageKeyboards/Swedish/SVCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVCommandVariables.swift
@@ -63,6 +63,7 @@ func svConjugationStateLeft() {
   case .active:
     break
   case .passive:
+    conjViewShiftButtonsState = .leftInactive
     svConjugationState = .active
   }
 }
@@ -71,6 +72,7 @@ func svConjugationStateLeft() {
 func svConjugationStateRight() {
   switch svConjugationState {
   case .active:
+    conjViewShiftButtonsState = .rightInactive
     svConjugationState = .passive
   case .passive:
     break


### PR DESCRIPTION
- PR for issue #211 
- Added an enum that holds the state for which button should be active.
- Assigned values to variable `conjViewShiftButtonsState` accordingly for all languages in their respective command variables file.
- Changed colour of chevron conditionally. I also used the `deactivate()` button method as otherwise it would still act as a button without performing any action.

@andrewtavis, could you please review these changes? 😊