### PR TITLE
Default autosuggestions after Pronouns in german

### DIFF
--- a/Keyboards/KeyboardsBase/InterfaceVariables.swift
+++ b/Keyboards/KeyboardsBase/InterfaceVariables.swift
@@ -291,6 +291,16 @@ func setENKeyboardLayout() {
   invalidCommandMsg = "Not in Wikidata"
   baseAutosuggestions = ["I", "I'm", "we"]
   numericAutosuggestions = ["is", "to", "and"]
+  wordsAfterPronounsArray = ["have", "be", "can"]
+  pronounsToPresentTenseDict = [
+    "I": "presFPS",
+    "we": "presFPP",
+    "you": "presFPP",
+    "he": "presTPS",
+    "they": "presTPP",
+    "she": "presTPS",
+    "it": "presTPS"
+  ]
 
   translateKeyLbl = "Translate"
   translatePrompt = commandPromptSpacing + "en -› \(getControllerLanguageAbbr()): "

--- a/Keyboards/KeyboardsBase/InterfaceVariables.swift
+++ b/Keyboards/KeyboardsBase/InterfaceVariables.swift
@@ -292,14 +292,14 @@ func setENKeyboardLayout() {
   baseAutosuggestions = ["I", "I'm", "we"]
   numericAutosuggestions = ["is", "to", "and"]
   wordsAfterPronounsArray = ["have", "be", "can"]
-  pronounsToPresentTenseDict = [
+  pronounAutosuggestionsDict = [
     "I": "presFPS",
-    "we": "presFPP",
-    "you": "presFPP",
+    "you": "presSPS",
     "he": "presTPS",
-    "they": "presTPP",
     "she": "presTPS",
-    "it": "presTPS"
+    "it": "presTPS",
+    "we": "presFPP",
+    "they": "presTPP"
   ]
 
   translateKeyLbl = "Translate"

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -266,15 +266,22 @@ class KeyboardViewController: UIInputViewController {
     }
   }
   
-  /// Currently only works for German language.
-  func getAutosuggestionsOnPronouns() {
+  /// Gets consistent autosguestions for all prnouns in the given language.
+  /// Note: currently only works for German language.
+  func getPronounAutosuggestions() {
     let prefix = proxy.documentContextBeforeInput?.components(separatedBy: " ").secondToLast() ?? ""
 
     completionWords = [String]()
     var i = 0
     while i < 3 {
-      let suggestion = verbs?[wordsAfterPronounsArray[i]]?[pronounsToPresentTenseDict[prefix]!] as! String
-      completionWords.append(suggestion)
+      let suggestion = verbs[wordsAfterPronounsArray[i]][pronounAutosuggestionsDict[prefix.lowercased()]!].string ?? ""
+      if shiftButtonState == .shift {
+        completionWords.append(suggestion.capitalize())
+      } else if shiftButtonState == .caps {
+        completionWords.append(suggestion.uppercased())
+      } else {
+        completionWords.append(suggestion)
+      }
       i += 1
     }
   }
@@ -301,8 +308,8 @@ class KeyboardViewController: UIInputViewController {
 
     if prefix.isNumeric {
       completionWords = numericAutosuggestions
-    } else if controllerLanguage == "German" && pronounsToPresentTenseDict.keys.contains(prefix) {
-      getAutosuggestionsOnPronouns()
+    } else if controllerLanguage == "German" && pronounAutosuggestionsDict.keys.contains(prefix.lowercased()) {
+      getPronounAutosuggestions()
     } else {
       /// We have to consider these different cases as the key always has to match.
       /// Else, even if the lowercased prefix is present in the dictionary, if the actual prefix isn't present we won't get an output.

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -265,6 +265,19 @@ class KeyboardViewController: UIInputViewController {
       getDefaultAutosuggestions()
     }
   }
+  
+  /// Currently only works for German language.
+  func getAutosuggestionsOnPronouns() {
+    let prefix = proxy.documentContextBeforeInput?.components(separatedBy: " ").secondToLast() ?? ""
+
+    completionWords = [String]()
+    var i = 0
+    while i < 3 {
+      let suggestion = verbs?[wordsAfterPronounsArray[i]]?[pronounsToPresentTenseDict[prefix]!] as! String
+      completionWords.append(suggestion)
+      i += 1
+    }
+  }
 
   /// Generates an array of three words that serve as baseline autosuggestions.
   func getDefaultAutosuggestions() {
@@ -288,6 +301,8 @@ class KeyboardViewController: UIInputViewController {
 
     if prefix.isNumeric {
       completionWords = numericAutosuggestions
+    } else if controllerLanguage == "German" && pronounsToPresentTenseDict.keys.contains(prefix) {
+      getAutosuggestionsOnPronouns()
     } else {
       /// We have to consider these different cases as the key always has to match.
       /// Else, even if the lowercased prefix is present in the dictionary, if the actual prefix isn't present we won't get an output.

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
@@ -24,6 +24,8 @@ let autosuggestions = loadJSONToDict(filename: "autosuggestions")
 var autocompleteWords = [String]()
 var baseAutosuggestions = [String]()
 var numericAutosuggestions = [String]()
+var pronounsToPresentTenseDict: [String: String] = [:]
+var wordsAfterPronounsArray = [String]()
 
 var currentPrefix: String = ""
 var pastStringInTextProxy: String = ""

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
@@ -24,7 +24,7 @@ let autosuggestions = loadJSONToDict(filename: "autosuggestions")
 var autocompleteWords = [String]()
 var baseAutosuggestions = [String]()
 var numericAutosuggestions = [String]()
-var pronounsToPresentTenseDict: [String: String] = [:]
+var pronounAutosuggestionsDict: [String: String] = [:]
 var wordsAfterPronounsArray = [String]()
 
 var currentPrefix: String = ""

--- a/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
@@ -117,6 +117,17 @@ func setDEKeyboardLayout() {
   invalidCommandMsg = "Nicht in Wikidata"
   baseAutosuggestions = ["ich", "die", "das"]
   numericAutosuggestions = ["Prozent", "Milionen", "Meter"]
+  wordsAfterPronounsArray = ["haben", "sein", "können"]
+  pronounsToPresentTenseDict = [
+    "ich": "presFPS",
+    "du": "presSPS",
+    "er": "presTPS",
+    "sie": "presTPS",
+    "es": "presTPS",
+    "wir": "presFPP",
+    "ihr": "presSPP",
+    "Sie": "presTPP"
+  ]
 
   translateKeyLbl = "Übersetzen"
   translatePlaceholder = "Wort eingeben"

--- a/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
@@ -118,7 +118,7 @@ func setDEKeyboardLayout() {
   baseAutosuggestions = ["ich", "die", "das"]
   numericAutosuggestions = ["Prozent", "Milionen", "Meter"]
   wordsAfterPronounsArray = ["haben", "sein", "können"]
-  pronounsToPresentTenseDict = [
+  pronounAutosuggestionsDict = [
     "ich": "presFPS",
     "du": "presSPS",
     "er": "presTPS",


### PR DESCRIPTION
- PR for issue #208 
- Added variables to hold pronouns to Present tense dictionary and also array for words that follow pronouns i.e. variations of [have, be, can].
- Created there corresponding instances in `DEInterfaceVariables`.
- Created a function that assigns the autosuggestions based on the values retrieved from the verbs dictionary.

@andrewtavis, I am hoping this is something close to what you intended. Let me know if you want me to make any changes. I created the `wordsAfterPronounsArray` so that it can be easier to add similar functionality for other languages later instead of hard coding the values directly in the function. 😊