### PR TITLE
#229 docs: add variant info in new_keyboard issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_keyboard.yml
+++ b/.github/ISSUE_TEMPLATE/new_keyboard.yml
@@ -28,6 +28,17 @@ body:
     validations:
       required: true
   - type: textarea
+    id: keyboard-variant
+    attributes:
+      label: Keyboard variants
+      placeholder: |
+        Are there any variants in keyboard layout for this language that Scribe should keep in mind?
+        For instance, French has two notable variants that are used in different countries:
+          - French QWERTY keyboard used in Canada
+          - French AZERTY keyboard used in France
+    validations:
+      required: true
+  - type: textarea
     id: contribution
     attributes:
       label: Contribution


### PR DESCRIPTION
What's in here:
- Adds a text form for information on keyboard variants in the `new_keyboard.yml` issue template 