### PR TITLE
Fix: allow for autocomplete after certain punctuation -- ", /, #, (

### DIFF
--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -220,6 +220,11 @@ class KeyboardViewController: UIInputViewController {
       if let inString = proxy.documentContextBeforeInput {
         // To only focus on the current word as prefix in autocomplete.
         currentPrefix = inString.replacingOccurrences(of: pastStringInTextProxy, with: "")
+        
+        if currentPrefix.hasPrefix("(") || currentPrefix.hasPrefix("#") ||
+           currentPrefix.hasPrefix("/") || currentPrefix.hasPrefix("\"") {
+          currentPrefix = currentPrefix.replacingOccurrences(of: #"[\"(\#\/]"#, with: "", options: .regularExpression)
+        }
 
         // Post commands pastStringInTextProxy is "", so take last word.
         if currentPrefix.contains(" ") {


### PR DESCRIPTION
Added `currentPrefix.hasPrefix()` checks for `"`, `/`, `#`, and `(`. If the word begins with any of those punctuation, then `replaceOccurrences` will remove it in order to get the autocompletions. If we didn't wan't to call `currentPrefix.hasPrefix()` multiple times in the if statement, another workaround could be to store the initial character of the word as a constant and then check if the constant is `"`, `/`, `#`, or `(`. If you would rather do it that way or another way let me know and I can change it.