### PR TITLE
Added support for highlight autocompletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 ### 🗃️ Data Added
 
 ### ✨ New Features
+- Added highlight for autocompletion if it is the word typed
 
 <!-- Scribe data is now loaded into SQLite database tables to make data reference less memory intensive and mitigate crashes. -->
 <!-- Emoji autosuggestions are now available as the user types. -->

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -369,7 +369,7 @@ class KeyboardViewController: UIInputViewController {
       deactivateBtn(btn: pluralKey)
 
       if autoAction1Visible == true {
-        setBtn(btn: translateKey, color: keyboardBgColor, name: "AutoAction1", canCap: false, isSpecial: false)
+        setBtn(btn: translateKey, color: currentPrefix == completionWords[0] ? keyColor.withAlphaComponent(0.5) : keyboardBgColor, name: "AutoAction1", canCap: false, isSpecial: false)
         styleBtn(btn: translateKey, title: completionWords[0], radius: commandKeyCornerRadius)
         activateBtn(btn: translateKey)
       }


### PR DESCRIPTION
<!--- Thank you for your pull request! 🚀 -->

### Contributor checklist

<!-- Please replace the empty checkboxes [ ] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have updated the [CHANGELOG](https://github.com/scribe-org/Scribe-iOS/blob/main/CHANGELOG.md) with a description of my changes for the upcoming release <!-- ... or I'll send a commit with this now 🙃 -->

---

### Description

<!--

-->

This pull request proposes to add support for highlighting the "AutoAction1" button given that the word being entered is the completion word at hand. The color of the button is changed to "keyColor" and given an alpha component to distinguish itself.

I tested that this change works by running Scribe in an emulator and typing the word listed in the "AutoAction1" button until they were a match. I then confirmed that the button was highlighted only when the word I had typed was the same as the word in the "AutoAction1" 

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->

#250 
