### PR TITLE
feat: Adding space to insert autocompletion and undo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 
 - Added action to command bar information icon.
 - Added highlight for autocompletion if it is the word typed.
+- If a word is the only autosuggestion, hitting the spacebar inserts the suggestion. Added undo functionality if the user does not want the completion.
 
 ### 🎨 Design Changes
 

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -451,6 +451,8 @@ class KeyboardViewController: UIInputViewController {
       deactivateBtn(btn: pluralKey)
 
       if autoAction1Visible == true {
+        allowUndo = false
+        shouldHighlightFirstCompletion = false
         if currentPrefix == completionWords[0] || completionWords[1] == " " {
           shouldHighlightFirstCompletion = true
         }
@@ -1920,7 +1922,7 @@ class KeyboardViewController: UIInputViewController {
       }
 
     case spaceBar, languageTextForSpaceBar:
-      if completionWords[1] == " " {
+      if completionWords[1] == " " && previousWord != completionWords[0] {
         previousWord = currentPrefix
         clearPrefixFromTextFieldProxy()
         proxy.insertText(completionWords[0])

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
@@ -9,7 +9,10 @@ import UIKit
 // Basic keyboard functionality variables.
 var capsLockPossible = false
 var doubleSpacePeriodPossible = false
-var autoAction1Visible: Bool = true
+var autoAction1Visible = true
+var shouldHighlightFirstCompletion = false
+var allowUndo = false
+var previousWord = ""
 var backspaceTimer: Timer?
 var scribeKeyHeight = CGFloat(0)
 


### PR DESCRIPTION
<!--- Thank you for your pull request! 🚀 -->

### Contributor checklist

<!-- Please replace the empty checkboxes [ ] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have updated the [CHANGELOG](https://github.com/scribe-org/Scribe-iOS/blob/main/CHANGELOG.md) with a description of my changes for the upcoming release (if necessary) <!-- ... or I'll send a commit with this now 🙃 -->

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

- Adds insertion of autocompletion on spacebar.
- This works in the case if the user is mid-word and if there is only one possible autocompletion.
- In the case the user does not want the completion, the user entered word is offered as the first suggestion which can undo the insertion.
- Stores the previous word and if undo is allowed as boolean in separate variables.
- Files changed:
  - KeyboardViewController.swift
  - CommandVariables.swift

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- PR for issue #256 

Hey @andrewtavis! Could you take a look at the changes? Sorry for the delay :)
