### PR TITLE
Add Autosuggestion texts to CommandBar after pressing Return

### DIFF
--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -1702,6 +1702,10 @@ class KeyboardViewController: UIInputViewController {
     case "return":
       if ![.translate, .conjugate, .plural].contains(commandState) { // normal return button
         proxy.insertText("\n")
+        commandState = .idle
+        autoActionState = .suggest
+        autoAction1Visible = false
+        conditionallySetAutoActionBtns()
       } else if commandState == .translate {
         queryTranslation(commandBar: commandBar)
       } else if commandState == .conjugate {

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -302,7 +302,16 @@ class KeyboardViewController: UIInputViewController {
 
         // Post commands pastStringInTextProxy is "", so take last word.
         if currentPrefix.contains(" ") {
-          currentPrefix = currentPrefix.components(separatedBy: " ").last ?? ""
+          currentPrefix = currentPrefix.components(
+            separatedBy: " "
+          ).last ?? ""
+        }
+
+        // If there's a line break, take the word after it.
+        if currentPrefix.contains("\n") {
+          currentPrefix = currentPrefix.components(
+            separatedBy: "\n"
+          ).last ?? ""
         }
 
         // Get options for completion that have start with the current prefix and are not just one letter.
@@ -388,7 +397,16 @@ class KeyboardViewController: UIInputViewController {
 
   /// Generates an array of the three autosuggest words.
   func getAutosuggestions() {
-    let prefix = proxy.documentContextBeforeInput?.components(separatedBy: " ").secondToLast() ?? ""
+    var prefix = proxy.documentContextBeforeInput?.components(
+      separatedBy: " "
+    ).secondToLast() ?? ""
+
+    // If there's a line break, take the word after it.
+    if prefix.contains("\n") {
+      prefix = prefix.components(
+        separatedBy: "\n"
+      ).last ?? ""
+    }
 
     if prefix.isNumeric {
       completionWords = numericAutosuggestions
@@ -1702,10 +1720,13 @@ class KeyboardViewController: UIInputViewController {
     case "return":
       if ![.translate, .conjugate, .plural].contains(commandState) { // normal return button
         proxy.insertText("\n")
+        if shiftButtonState == .normal { // capitalize the proxy
+          shiftButtonState = .shift
+        }
         commandState = .idle
         autoActionState = .suggest
-        autoAction1Visible = false
         conditionallySetAutoActionBtns()
+        loadKeys()
       } else if commandState == .translate {
         queryTranslation(commandBar: commandBar)
       } else if commandState == .conjugate {


### PR DESCRIPTION
<!--- Thank you for your pull request! 🚀 -->

### Contributor checklist

<!-- Please replace the empty checkboxes [ ] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have updated the [CHANGELOG](https://github.com/scribe-org/Scribe-iOS/blob/main/CHANGELOG.md) with a description of my changes for the upcoming release (if necessary) <!-- ... or I'll send a commit with this now 🙃 -->

---

### Description

This pull request modifies the KeyboardViewController.swift file to fix the bug of not showing suggestions after pressing the "Return Key". I have essentially set the commandState to idle and called conditionallySetAutoActionBtns() functions from CommandBar class to set the texts. 

The CommandBar works now and displays default auto suggestion texts after pressing return

Please review it and tell me if any changes are necessary. Thank you
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

#ISSUE_NUMBER
This PR fixes issue for #270 
