### PR TITLE
Insert em dash when user does double dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 - If a word is the only autosuggestion, hitting the space bar inserts the suggestion. Added undo functionality if the user does not want the completion.
 - Added Demonstrative pronouns to German preposition declension tables.
 - Added contracted preposition annotation to the German keyboard.
-
+- Double dash inserts em dash in proxy
 ### 🎨 Design Changes
 
 - The resolution of the Scribe key has been improved.

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -2151,6 +2151,18 @@ class KeyboardViewController: UIInputViewController {
       }
       changeKeyboardToLetterKeys()
 
+    case "-":
+      if [.idle, .selectCommand, .alreadyPlural, .invalid].contains(commandState) {
+        if proxy.documentContextBeforeInput?.last == "-" {
+          proxy.deleteBackward()
+          proxy.insertText("—")
+        } else {
+          proxy.insertText(keyToDisplay)
+        }
+      } else {
+        commandBar.text = commandBar.text!.insertPriorToCursor(char: keyToDisplay)
+      }
+      
     case ",", ".", "!", "?":
       if [.idle, .selectCommand, .alreadyPlural, .invalid].contains(commandState) {
         if proxy.documentContextBeforeInput?.last == " " {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀

If you're not already a member of our public Matrix community, please consider joining via the following link:
https://matrix.to/#/#scribe_community:matrix.org

It'd be great to have you!

Also uf you're new to open source, check that the email you use for GitHub (https://github.com/settings/emails) is the same the one you have for git so you get credit for your contribution. You can see your git email by typing `git config user.email` and set it globally with `git config --global user.email "your_email@email.com"`.
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [ ] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have updated the [CHANGELOG](https://github.com/scribe-org/Scribe-iOS/blob/main/CHANGELOG.md) with a description of my changes for the upcoming release (if necessary) <!-- ... or I'll send a commit with this now 🙃 -->

---

### Description

Insert em dash when type double dash.

Tested on simulator iOS 16.2

### Related issue

- [#280](https://github.com/scribe-org/Scribe-iOS/issues/280)
