### PR TITLE
fix: removed all explicit boolean comparisons

### DIFF
--- a/Keyboards/KeyboardsBase/KeyAltChars.swift
+++ b/Keyboards/KeyboardsBase/KeyAltChars.swift
@@ -117,13 +117,13 @@ func setAlternatesPathState(
   if DeviceType.isPad {
     widthMultiplier = 0.2
     maxHeightMultiplier = 2.05
-    if isLandscapeView == true {
+    if isLandscapeView {
       maxHeightMultiplier = 1.95
     }
   } else if DeviceType.isPhone {
     widthMultiplier = 0.4
     maxHeightMultiplier = 2.125
-    if isLandscapeView == true {
+    if isLandscapeView {
       widthMultiplier = 0.2
     }
   }
@@ -135,7 +135,7 @@ func setAlternatesPathState(
   if DeviceType.isPhone {
     heightBeforeTopCurves = vertStart - (keyHeight * 1.8)
     maxWidthCurveControl = keyWidth * 0.5
-  } else if DeviceType.isPad || (DeviceType.isPhone && isLandscapeView == true) {
+  } else if DeviceType.isPad || (DeviceType.isPhone && isLandscapeView) {
     heightBeforeTopCurves = vertStart - (keyHeight * 1.6)
     maxWidthCurveControl = keyWidth * 0.25
   }

--- a/Keyboards/KeyboardsBase/KeyAnimation.swift
+++ b/Keyboards/KeyboardsBase/KeyAnimation.swift
@@ -26,10 +26,10 @@ func setPopPathState(
   if DeviceType.isPad {
     widthMultiplier = 0.2
     maxHeightMultiplier = 2.05
-    if isLandscapeView == true {
+    if isLandscapeView  {
       maxHeightMultiplier = 1.95
     }
-  } else if DeviceType.isPhone && isLandscapeView == true {
+  } else if DeviceType.isPhone && isLandscapeView {
     widthMultiplier = 0.2
     maxHeightMultiplier = 2.125
   } else if DeviceType.isPhone && [".", ",", "?", "!", "'"].contains(char) {
@@ -49,7 +49,7 @@ func setPopPathState(
 
   if DeviceType.isPhone {
     heightBeforeTopCurves = vertStart - (keyHeight * 1.8)
-  } else if DeviceType.isPad || (DeviceType.isPhone && isLandscapeView == true) {
+  } else if DeviceType.isPad || (DeviceType.isPhone && isLandscapeView) {
     heightBeforeTopCurves = vertStart - (keyHeight * 1.6)
   }
 }
@@ -260,12 +260,12 @@ func getKeyPopPath(key: UIButton, layer: CAShapeLayer, char: String, displayChar
   let frame = (key.superview?.convert(key.frame, to: nil))!
   var labelVertPosition = frame.origin.y - key.frame.height / 1.75
   // non-capital characters should be higher for portrait phone views.
-  if displayChar == char, DeviceType.isPhone, isLandscapeView == false,
+  if displayChar == char, DeviceType.isPhone, !isLandscapeView,
      !["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"].contains(char)
   {
     labelVertPosition = frame.origin.y - key.frame.height / 1.6
   } else if DeviceType.isPad,
-            isLandscapeView == true
+            isLandscapeView
   {
     labelVertPosition = frame.origin.y - key.frame.height / 2
   }
@@ -284,7 +284,7 @@ func getKeyPopPath(key: UIButton, layer: CAShapeLayer, char: String, displayChar
     ).cgPath
     keyPopChar.center = CGPoint(x: frame.origin.x + key.frame.width * 0.85, y: labelVertPosition)
     keyHoldPopChar.center = CGPoint(x: frame.origin.x + key.frame.width * 0.85, y: labelVertPosition)
-    if DeviceType.isPad || (DeviceType.isPhone && isLandscapeView == true) {
+    if DeviceType.isPad || (DeviceType.isPhone && isLandscapeView) {
       keyPopChar.center = CGPoint(x: frame.origin.x + key.frame.width * 0.65, y: labelVertPosition)
       keyHoldPopChar.center = CGPoint(x: frame.origin.x + key.frame.width * 0.65, y: labelVertPosition)
     }
@@ -295,7 +295,7 @@ func getKeyPopPath(key: UIButton, layer: CAShapeLayer, char: String, displayChar
     ).cgPath
     keyPopChar.center = CGPoint(x: frame.origin.x + key.frame.width * 0.15, y: labelVertPosition)
     keyHoldPopChar.center = CGPoint(x: frame.origin.x + key.frame.width * 0.15, y: labelVertPosition)
-    if DeviceType.isPad || (DeviceType.isPhone && isLandscapeView == true) {
+    if DeviceType.isPad || (DeviceType.isPhone && isLandscapeView) {
       keyPopChar.center = CGPoint(x: frame.origin.x + key.frame.width * 0.35, y: labelVertPosition)
       keyHoldPopChar.center = CGPoint(x: frame.origin.x + key.frame.width * 0.35, y: labelVertPosition)
     }
@@ -312,7 +312,7 @@ func getKeyPopPath(key: UIButton, layer: CAShapeLayer, char: String, displayChar
 ///   - char: the character of the key.
 func setPhoneKeyPopCharSize(char: String) {
   if keyboardState != .letters && !["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"].contains(char) {
-    if isLandscapeView == true {
+    if isLandscapeView {
       keyPopChar.font = .systemFont(ofSize: letterKeyWidth / 2.25)
       keyHoldPopChar.font = .systemFont(ofSize: letterKeyWidth / 2.25)
     } else {
@@ -320,7 +320,7 @@ func setPhoneKeyPopCharSize(char: String) {
       keyHoldPopChar.font = .systemFont(ofSize: letterKeyWidth / 1.15)
     }
   } else if shiftButtonState == .shift || shiftButtonState == .caps {
-    if isLandscapeView == true {
+    if isLandscapeView {
       keyPopChar.font = .systemFont(ofSize: letterKeyWidth / 2.15)
       keyHoldPopChar.font = .systemFont(ofSize: letterKeyWidth / 2.15)
     } else {
@@ -328,7 +328,7 @@ func setPhoneKeyPopCharSize(char: String) {
       keyHoldPopChar.font = .systemFont(ofSize: letterKeyWidth / 1)
     }
   } else {
-    if isLandscapeView == true {
+    if isLandscapeView {
       keyPopChar.font = .systemFont(ofSize: letterKeyWidth / 2)
       keyHoldPopChar.font = .systemFont(ofSize: letterKeyWidth / 2)
     } else {
@@ -344,7 +344,7 @@ func setPhoneKeyPopCharSize(char: String) {
 ///   - char: the character of the key.
 func setPadKeyPopCharSize(char: String) {
   if keyboardState != .letters, !["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"].contains(char) {
-    if isLandscapeView == true {
+    if isLandscapeView {
       keyPopChar.font = .systemFont(ofSize: letterKeyWidth / 2.75)
       keyHoldPopChar.font = .systemFont(ofSize: letterKeyWidth / 2.75)
     } else {
@@ -352,7 +352,7 @@ func setPadKeyPopCharSize(char: String) {
       keyHoldPopChar.font = .systemFont(ofSize: letterKeyWidth / 2.5)
     }
   } else if keyboardState == .letters, shiftButtonState == .shift || shiftButtonState == .caps {
-    if isLandscapeView == true {
+    if isLandscapeView {
       keyPopChar.font = .systemFont(ofSize: letterKeyWidth / 2.5)
       keyHoldPopChar.font = .systemFont(ofSize: letterKeyWidth / 2.5)
     } else {
@@ -360,7 +360,7 @@ func setPadKeyPopCharSize(char: String) {
       keyHoldPopChar.font = .systemFont(ofSize: letterKeyWidth / 2)
     }
   } else {
-    if isLandscapeView == true {
+    if isLandscapeView {
       keyPopChar.font = .systemFont(ofSize: letterKeyWidth / 2.25)
       keyHoldPopChar.font = .systemFont(ofSize: letterKeyWidth / 2.25)
     } else {

--- a/Keyboards/KeyboardsBase/KeyboardKeys.swift
+++ b/Keyboards/KeyboardsBase/KeyboardKeys.swift
@@ -85,7 +85,7 @@ class KeyboardKey: UIButton {
 
   /// Sets the character size of a capital key if the device is an iPhone given the orientation.
   func setPhoneCapCharSize() {
-    if isLandscapeView == true {
+    if isLandscapeView {
       if key == "#+="
         || key == "ABC"
         || key == "АБВ"
@@ -117,13 +117,13 @@ class KeyboardKey: UIButton {
     guard let isSpecial = layer.value(forKey: "isSpecial") as? Bool else { return }
 
     if keyboardState == .letters
-      && isSpecial == false
+      && !isSpecial
       && !["123", "´", spaceBar, languageTextForSpaceBar].contains(key)
       && shiftButtonState == .normal
     {
       titleEdgeInsets = UIEdgeInsets(top: -4.0, left: 0.0, bottom: 0.0, right: 0.0)
 
-      if isLandscapeView == true {
+      if isLandscapeView {
         titleLabel?.font = .systemFont(ofSize: letterKeyWidth / 2.4)
       } else {
         titleLabel?.font = .systemFont(ofSize: letterKeyWidth / 1.35)
@@ -141,7 +141,7 @@ class KeyboardKey: UIButton {
 
   /// Sets the character size of a key if the device is an iPad given the orientation.
   func setPadCapCharSize() {
-    if isLandscapeView == true {
+    if isLandscapeView {
       if key == "#+="
         || key == "ABC"
         || key == "АБВ"
@@ -177,13 +177,13 @@ class KeyboardKey: UIButton {
     guard let isSpecial = layer.value(forKey: "isSpecial") as? Bool else { return }
 
     if keyboardState == .letters
-      && isSpecial == false
+      && !isSpecial
       && ![".?123", spaceBar, languageTextForSpaceBar, "ß", "´", ",", ".", "'", "-"].contains(key)
       && shiftButtonState == .normal
     {
       titleEdgeInsets = UIEdgeInsets(top: -4.0, left: 0.0, bottom: 0.0, right: 0.0)
 
-      if isLandscapeView == true {
+      if isLandscapeView {
         titleLabel?.font = .systemFont(ofSize: letterKeyWidth / 3.35)
       } else {
         titleLabel?.font = .systemFont(ofSize: letterKeyWidth / 2.75)
@@ -308,7 +308,7 @@ class KeyboardKey: UIButton {
     } else if key == "return" && [.translate, .conjugate, .plural].contains(commandState) {
       // Color the return key depending on if it's being used as enter for commands.
       backgroundColor = commandKeyColor
-    } else if isSpecial == true {
+    } else if isSpecial {
       backgroundColor = specialKeyColor
     }
   }
@@ -329,7 +329,7 @@ func setBtn(btn: UIButton, color: UIColor, name: String, canCap: Bool, isSpecial
   let charsWithoutShiftState = ["ß"]
 
   var capsKey = ""
-  if canCap == true {
+  if canCap {
     if !charsWithoutShiftState.contains(name) {
       capsKey = name.capitalized
     } else {

--- a/Keyboards/KeyboardsBase/KeyboardStyling.swift
+++ b/Keyboards/KeyboardsBase/KeyboardStyling.swift
@@ -61,7 +61,7 @@ func getPhoneIconConfig(iconName: String) -> UIImage.SymbolConfiguration {
       scale: .medium
     )
   }
-  if isLandscapeView == true {
+  if isLandscapeView {
     iconConfig = UIImage.SymbolConfiguration(
       pointSize: letterKeyWidth / 3.5,
       weight: .light,
@@ -96,7 +96,7 @@ func getPadIconConfig(iconName: String) -> UIImage.SymbolConfiguration {
       scale: .medium
     )
   }
-  if isLandscapeView == true {
+  if isLandscapeView {
     iconConfig = UIImage.SymbolConfiguration(
       pointSize: letterKeyWidth / 3.75,
       weight: .light,

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -92,13 +92,13 @@ class KeyboardViewController: UIInputViewController {
 
     checkLandscapeMode()
     if DeviceType.isPhone {
-      if isLandscapeView == true {
+      if isLandscapeView {
         keyboardHeight = 200
       } else {
         keyboardHeight = 270
       }
     } else if DeviceType.isPad {
-      if isLandscapeView == true {
+      if isLandscapeView {
         keyboardHeight = 420
       } else {
         keyboardHeight = 340
@@ -464,7 +464,7 @@ class KeyboardViewController: UIInputViewController {
       separatedBy: " "
     ).secondToLast() ?? ""
 
-    if emojiAutoActionRepeatPossible == true {
+    if emojiAutoActionRepeatPossible {
       prefix = currentEmojiTriggerWord
     }
 
@@ -600,7 +600,7 @@ class KeyboardViewController: UIInputViewController {
       deactivateBtn(btn: padEmojiKey2)
       deactivateBtn(btn: padEmojiKey3)
 
-      if autoAction1Visible == true {
+      if autoAction1Visible {
         allowUndo = false
         shouldHighlightFirstCompletion = false
         // Highlight if the current prefix is the first autocompletion or there is only one available.
@@ -616,13 +616,13 @@ class KeyboardViewController: UIInputViewController {
       styleBtn(btn: conjugateKey, title: !autoAction1Visible ? completionWords[0] : completionWords[1], radius: commandKeyCornerRadius)
       activateBtn(btn: conjugateKey)
 
-      if autoAction3Visible == true && emojisToShow == .zero {
+      if autoAction3Visible && emojisToShow == .zero {
         setBtn(btn: pluralKey, color: keyboardBgColor, name: "AutoAction3", canCap: false, isSpecial: false)
         styleBtn(btn: pluralKey, title: !autoAction1Visible ? completionWords[1] : completionWords[2], radius: commandKeyCornerRadius)
         activateBtn(btn: pluralKey)
 
         conditionallyHideEmojiDividers()
-      } else if autoAction3Visible == true && emojisToShow == .one {
+      } else if autoAction3Visible && emojisToShow == .one {
         setBtn(btn: pluralKey, color: keyboardBgColor, name: "AutoAction3", canCap: false, isSpecial: false)
         styleBtn(btn: pluralKey, title: emojisToDisplayArray[0], radius: commandKeyCornerRadius)
         if DeviceType.isPhone {
@@ -633,7 +633,7 @@ class KeyboardViewController: UIInputViewController {
         activateBtn(btn: pluralKey)
 
         conditionallyHideEmojiDividers()
-      } else if autoAction3Visible == false && emojisToShow == .two {
+      } else if !autoAction3Visible && emojisToShow == .two {
         setBtn(btn: phoneEmojiKey1, color: keyboardBgColor, name: "EmojiKey1", canCap: false, isSpecial: false)
         setBtn(btn: phoneEmojiKey2, color: keyboardBgColor, name: "EmojiKey2", canCap: false, isSpecial: false)
         styleBtn(btn: phoneEmojiKey1, title: emojisToDisplayArray[0], radius: commandKeyCornerRadius)
@@ -651,7 +651,7 @@ class KeyboardViewController: UIInputViewController {
         activateBtn(btn: phoneEmojiKey2)
 
         conditionallyHideEmojiDividers()
-      } else if autoAction3Visible == false && emojisToShow == .three {
+      } else if !autoAction3Visible && emojisToShow == .three {
         setBtn(btn: padEmojiKey1, color: keyboardBgColor, name: "EmojiKey1", canCap: false, isSpecial: false)
         setBtn(btn: padEmojiKey2, color: keyboardBgColor, name: "EmojiKey2", canCap: false, isSpecial: false)
         setBtn(btn: padEmojiKey3, color: keyboardBgColor, name: "EmojiKey3", canCap: false, isSpecial: false)
@@ -718,7 +718,7 @@ class KeyboardViewController: UIInputViewController {
     clearPrefixFromTextFieldProxy()
     emojisToDisplayArray = [String]()
     // Remove the space from the previous auto action or replace the current prefix.
-    if emojiAutoActionRepeatPossible == true && (
+    if emojiAutoActionRepeatPossible && (
       (keyPressed == phoneEmojiKey1 || keyPressed == phoneEmojiKey2)
         || (keyPressed == padEmojiKey1 || keyPressed == padEmojiKey2 || keyPressed == padEmojiKey3)
         || (keyPressed == pluralKey && emojisToShow == .one)
@@ -1447,7 +1447,7 @@ class KeyboardViewController: UIInputViewController {
     controllerLanguage = classForCoder.description().components(separatedBy: ".KeyboardViewController")[0]
 
     // Actions to be done only on initial loads.
-    if firstKeyboardLoad == true {
+    if firstKeyboardLoad {
       shiftButtonState = .shift
       commandBar.textColor = keyCharColor
       commandBar.conditionallyAddPlaceholder() // in case of color mode change during commands
@@ -1512,7 +1512,7 @@ class KeyboardViewController: UIInputViewController {
     setConjugationBtns()
 
     // Clear annotation state if a keyboard state change dictates it.
-    if annotationState == false {
+    if !annotationState {
       annotationBtns.forEach { $0.removeFromSuperview() }
       annotationBtns.removeAll()
       annotationSeparators.forEach { $0.removeFromSuperview() }
@@ -1524,7 +1524,7 @@ class KeyboardViewController: UIInputViewController {
     paddingViews.forEach { $0.removeFromSuperview() }
 
     // keyWidth determined per keyboard by the top row.
-    if isLandscapeView == true {
+    if isLandscapeView {
       if DeviceType.isPhone {
         letterKeyWidth = (UIScreen.main.bounds.height - 5) / CGFloat(letterKeys[0].count) * 1.5
         numSymKeyWidth = (UIScreen.main.bounds.height - 5) / CGFloat(numberKeys[0].count) * 1.5
@@ -1556,7 +1556,7 @@ class KeyboardViewController: UIInputViewController {
 
     // Derive corner radii.
     if DeviceType.isPhone {
-      if isLandscapeView == true {
+      if isLandscapeView {
         keyCornerRadius = keyWidth / 9
         commandKeyCornerRadius = keyWidth / 5
       } else {
@@ -1564,7 +1564,7 @@ class KeyboardViewController: UIInputViewController {
         commandKeyCornerRadius = keyWidth / 3
       }
     } else if DeviceType.isPad {
-      if isLandscapeView == true {
+      if isLandscapeView {
         keyCornerRadius = keyWidth / 12
         commandKeyCornerRadius = keyWidth / 7.5
       } else {
@@ -1654,7 +1654,7 @@ class KeyboardViewController: UIInputViewController {
           commandBar.text = ""
           commandBar.hide()
           // Set autosuggestions on keyboard's first load.
-          if firstKeyboardLoad == true {
+          if firstKeyboardLoad {
             conditionallySetAutoActionBtns()
           }
         }
@@ -1995,7 +1995,7 @@ class KeyboardViewController: UIInputViewController {
       } else if commandState == .conjugate {
         resetVerbConjugationState()
         let triggerConjugationTbl = triggerVerbConjugation(commandBar: commandBar)
-        if triggerConjugationTbl == true {
+        if triggerConjugationTbl {
           commandState = .selectVerbConjugation
           loadKeys() // go to conjugation view
           return
@@ -2393,7 +2393,7 @@ class KeyboardViewController: UIInputViewController {
     conditionallyShowAutoActionPartitions()
     conditionallySetAutoActionBtns()
 
-    if annotationState == false {
+    if !annotationState {
       annotationBtns.forEach { $0.removeFromSuperview() }
       annotationBtns.removeAll()
       annotationSeparators.forEach { $0.removeFromSuperview() }
@@ -2466,7 +2466,7 @@ class KeyboardViewController: UIInputViewController {
     let touch: UITouch = event.allTouches!.first!
 
     // Caps lock given two taps of shift.
-    if touch.tapCount == 2 && originalKey == "shift" && capsLockPossible == true {
+    if touch.tapCount == 2 && originalKey == "shift" && capsLockPossible {
       shiftButtonState = .caps
       loadKeys()
       conditionallySetAutoActionBtns()
@@ -2489,7 +2489,7 @@ class KeyboardViewController: UIInputViewController {
     if touch.tapCount == 2
       && (originalKey == spaceBar || originalKey == languageTextForSpaceBar)
       && proxy.documentContextBeforeInput?.count != 1
-      && doubleSpacePeriodPossible == true
+      && doubleSpacePeriodPossible
     {
       // The fist condition prevents a period if the prior characters are spaces as the user wants a series of spaces.
       if proxy.documentContextBeforeInput?.suffix(2) != "  " && ![.translate, .conjugate, .plural].contains(commandState) {

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
@@ -227,7 +227,7 @@ func returnConjugation(keyPressed: UIButton, requestedForm: String) {
       let outputCols = [requestedForm]
       wordToReturn = queryDBRow(query: query, outputCols: outputCols, args: args)[0]
 
-      if inputWordIsCapitalized == true {
+      if inputWordIsCapitalized {
         proxy.insertText(wordToReturn.capitalized + " ")
       } else {
         proxy.insertText(wordToReturn + " ")
@@ -246,7 +246,7 @@ func returnConjugation(keyPressed: UIButton, requestedForm: String) {
     let outputCols = [requestedForm]
     wordToReturn = queryDBRow(query: query, outputCols: outputCols, args: args)[0]
 
-    if inputWordIsCapitalized == true {
+    if inputWordIsCapitalized {
       proxy.insertText(wordToReturn.capitalized + " ")
     } else {
       proxy.insertText(wordToReturn + " ")

--- a/Keyboards/LanguageKeyboards/French/FRCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FRCommandVariables.swift
@@ -30,7 +30,7 @@ var frConjugationState: FRConjugationState = .indicativePresent
 
 /// Sets the title of the command bar when the keyboard is in conjugate mode.
 func frGetConjugationTitle() -> String {
-  if inputWordIsCapitalized == true {
+  if inputWordIsCapitalized {
     verbToDisplay = verbToConjugate.capitalized
   } else {
     verbToDisplay = verbToConjugate

--- a/Keyboards/LanguageKeyboards/German/DECommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DECommandVariables.swift
@@ -155,7 +155,7 @@ let contractedGermanPrepositions = [
 
 /// Sets the title of the command bar when the keyboard is in conjugate mode.
 func deGetConjugationTitle() -> String {
-  if inputWordIsCapitalized == true {
+  if inputWordIsCapitalized {
     verbToDisplay = verbToConjugate.capitalized
   } else {
     verbToDisplay = verbToConjugate

--- a/Keyboards/LanguageKeyboards/Italian/ITCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITCommandVariables.swift
@@ -29,7 +29,7 @@ var itConjugationState: ITConjugationState = .present
 
 /// Sets the title of the command bar when the keyboard is in conjugate mode.
 func itGetConjugationTitle() -> String {
-  if inputWordIsCapitalized == true {
+  if inputWordIsCapitalized {
     verbToDisplay = verbToConjugate.capitalized
   } else {
     verbToDisplay = verbToConjugate

--- a/Keyboards/LanguageKeyboards/Portuguese/PTCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTCommandVariables.swift
@@ -30,7 +30,7 @@ var ptConjugationState: PTConjugationState = .indicativePresent
 
 /// Sets the title of the command bar when the keyboard is in conjugate mode.
 func ptGetConjugationTitle() -> String {
-  if inputWordIsCapitalized == true {
+  if inputWordIsCapitalized {
     verbToDisplay = verbToConjugate.capitalized
   } else {
     verbToDisplay = verbToConjugate

--- a/Keyboards/LanguageKeyboards/Russian/RUCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUCommandVariables.swift
@@ -60,7 +60,7 @@ var ruCaseDeclensionState: RUCaseDeclensionState = .accusative
 
 /// Sets the title of the command bar when the keyboard is in conjugate mode.
 func ruGetConjugationTitle() -> String {
-  if inputWordIsCapitalized == true {
+  if inputWordIsCapitalized {
     verbToDisplay = verbToConjugate.capitalized
   } else {
     verbToDisplay = verbToConjugate

--- a/Keyboards/LanguageKeyboards/Spanish/ESCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESCommandVariables.swift
@@ -46,7 +46,7 @@ var esConjugationState: ESConjugationState = .indicativePresent
 
 /// Sets the title of the command bar when the keyboard is in conjugate mode.
 func esGetConjugationTitle() -> String {
-  if inputWordIsCapitalized == true {
+  if inputWordIsCapitalized {
     verbToDisplay = verbToConjugate.capitalized
   } else {
     verbToDisplay = verbToConjugate

--- a/Keyboards/LanguageKeyboards/Swedish/SVCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVCommandVariables.swift
@@ -34,7 +34,7 @@ var svConjugationState: SVConjugationState = .active
 
 /// Sets the title of the command bar when the keyboard is in conjugate mode.
 func svGetConjugationTitle() -> String {
-  if inputWordIsCapitalized == true {
+  if inputWordIsCapitalized {
     verbToDisplay = verbToConjugate.capitalized
   } else {
     verbToDisplay = verbToConjugate

--- a/Scribe/ViewController.swift
+++ b/Scribe/ViewController.swift
@@ -96,9 +96,9 @@ class ViewController: UIViewController {
 
   /// Sets the functionality of the button that switches between installation instructions and the privacy policy.
   func setSwitchViewBtn() {
-    if displayPrivacyPolicy == false {
+    if !displayPrivacyPolicy {
       switchView.setTitle(userSystemLanguage == "DE" ? "Datenschutzrichtlinie ansehen" : "View privacy policy", for: .normal)
-    } else if displayPrivacyPolicy == true {
+    } else if displayPrivacyPolicy {
       switchView.setTitle(userSystemLanguage == "DE" ? "Installation ansehen" : "View installation", for: .normal)
     }
     switchView.contentHorizontalAlignment = UIControl.ContentHorizontalAlignment.center
@@ -316,7 +316,7 @@ class ViewController: UIViewController {
     setUIConstantProperties()
     setUIDeviceProperties()
 
-    if displayPrivacyPolicy == false {
+    if !displayPrivacyPolicy {
       setInstallationUI()
     } else {
       setPrivacyUI()
@@ -325,7 +325,7 @@ class ViewController: UIViewController {
 
   /// Switches the view of the app based on the current view.
   @objc func switchAppView() {
-    if displayPrivacyPolicy == false {
+    if !displayPrivacyPolicy {
       displayPrivacyPolicy = true
     } else {
       displayPrivacyPolicy = false


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀

If you're not already a member of our public Matrix community, please consider joining via the following link:
https://matrix.to/#/#scribe_community:matrix.org

It'd be great to have you!

Also if you're new to open source, check that the email you use for GitHub (https://github.com/settings/emails) is the same the one you have for git so you get credit for your contribution. You can see your git email by typing `git config user.email` and set it globally with `git config --global user.email "your_email@email.com"`.
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [ ] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [ ] I have updated the [CHANGELOG](https://github.com/scribe-org/Scribe-iOS/blob/main/CHANGELOG.md) with a description of my changes for the upcoming release (if necessary) <!-- ... or I'll send a commit with this now 🙃 -->

---

### Description

<!--
In response to "Make boolean checks consistent throughout the app #289" I got rid off all explicit comparisons (except for optional bools where they are required).

I successfully built on my machine and then fiddled around with Scribe in messages to see if I saw any buggy behavior
-->

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #289 
