### PR TITLE
Implemented and ignored number key row for ipad.

### DIFF
--- a/Keyboards/KeyboardsBase/InterfaceVariables.swift
+++ b/Keyboards/KeyboardsBase/InterfaceVariables.swift
@@ -218,7 +218,8 @@ public enum EnglishKeyboardConstants {
   ]
 
   static let letterKeysPad = [
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"],
+    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0","-", "=", "delete"],
+    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
     ["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"],
     ["shift", "w", "x", "c", "v", "b", "n", "m", ",", ".", "shift"],
     [".?123", "selectKeyboard", "space", ".?123", "hideKeyboard"], // "undoArrow"
@@ -270,9 +271,15 @@ func getENKeys() {
     letterKeys = EnglishKeyboardConstants.letterKeysPad
     numberKeys = EnglishKeyboardConstants.numberKeysPad
     symbolKeys = EnglishKeyboardConstants.symbolKeysPad
+    
+    //if the ipad is too samll for numbers
+    letterKeys.removeFirst(1)
+    letterKeys[0].append("delete")
+    
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "1"]
+    // TODO: add "p" to rightKeyChar if has 4 rows
     rightKeyChars = []
     centralKeyChars = allKeys.filter { !leftKeyChars.contains($0) && !rightKeyChars.contains($0) }
   }

--- a/Keyboards/LanguageKeyboards/French/French-AZERTY/FR-AZERTYInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/French-AZERTY/FR-AZERTYInterfaceVariables.swift
@@ -28,7 +28,8 @@ public enum FrenchAZERTYKeyboardConstants {
   ]
 
   static let letterKeysPad = [
-    ["a", "z", "e", "r", "t", "y", "u", "i", "o", "p", "delete"],
+    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0","-", "=", "delete"],
+    ["a", "z", "e", "r", "t", "y", "u", "i", "o", "p"],
     ["q", "s", "d", "f", "g", "h", "j", "k", "l", "m", "return"],
     ["shift", "w", "x", "c", "v", "b", "n", "´", ",", ".", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "undoArrow"
@@ -78,9 +79,15 @@ func getFRAZERTYKeys() {
     letterKeys = FrenchAZERTYKeyboardConstants.letterKeysPad
     numberKeys = FrenchAZERTYKeyboardConstants.numberKeysPad
     symbolKeys = FrenchAZERTYKeyboardConstants.symbolKeysPad
+    
+    //if the ipad is too samll for numbers
+    letterKeys.removeFirst(1)
+    letterKeys[0].append("delete")
+    
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "a", "1", "@", "~"]
+    // TODO: add "p" to rightKeyChar if has 4 rows
     rightKeyChars = []
     centralKeyChars = allKeys.filter { !leftKeyChars.contains($0) && !rightKeyChars.contains($0) }
   }

--- a/Keyboards/LanguageKeyboards/French/French-QWERTY/FR-QWERTYInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/French-QWERTY/FR-QWERTYInterfaceVariables.swift
@@ -28,7 +28,8 @@ public enum FrenchQWERTYKeyboardConstants {
   ]
 
   static let letterKeysPad = [
-    ["a", "z", "e", "r", "t", "y", "u", "i", "o", "p", "delete"],
+    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0","-", "=", "delete"],
+    ["a", "z", "e", "r", "t", "y", "u", "i", "o", "p"],
     ["q", "s", "d", "f", "g", "h", "j", "k", "l", "m", "return"],
     ["shift", "w", "x", "c", "v", "b", "n", "´", ",", ".", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "undoArrow"
@@ -78,6 +79,11 @@ func getFRQWERTYKeys() {
     letterKeys = FrenchQWERTYKeyboardConstants.letterKeysPad
     numberKeys = FrenchQWERTYKeyboardConstants.numberKeysPad
     symbolKeys = FrenchQWERTYKeyboardConstants.symbolKeysPad
+    
+    //if the ipad is too samll for numbers
+    letterKeys.removeFirst(1)
+    letterKeys[0].append("delete")
+    
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "a", "1", "@", "~"]

--- a/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
@@ -30,7 +30,8 @@ public enum GermanKeyboardConstants {
   ]
 
   static let letterKeysPad = [
-    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "ü", "delete"],
+    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0","-", "=", "delete"],
+    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "ü"],
     ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "return"],
     ["shift", "y", "x", "c", "v", "b", "n", "m", ",", ".", "ß", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "undoArrow"
@@ -83,9 +84,15 @@ func getDEKeys() {
     letterKeys = GermanKeyboardConstants.letterKeysPad
     numberKeys = GermanKeyboardConstants.numberKeysPad
     symbolKeys = GermanKeyboardConstants.symbolKeysPad
+    
+    //if the ipad is too samll for numbers
+    letterKeys.removeFirst(1)
+    letterKeys[0].append("delete")
+    
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "a", "1", "\"", "$"]
+    // TODO: add "ü" to rightKeyChar if has 4 rows
     rightKeyChars = []
     centralKeyChars = allKeys.filter { !leftKeyChars.contains($0) && !rightKeyChars.contains($0) }
   }

--- a/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
@@ -30,7 +30,8 @@ public enum ItalianKeyboardConstants {
   ]
 
   static let letterKeysPad = [
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"],
+    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0","-", "=", "delete"],
+    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
     ["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"],
     ["shift", "z", "x", "c", "v", "b", "n", "m", ",", ".", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "undoArrow"
@@ -80,9 +81,15 @@ func getITKeys() {
     letterKeys = ItalianKeyboardConstants.letterKeysPad
     numberKeys = ItalianKeyboardConstants.numberKeysPad
     symbolKeys = ItalianKeyboardConstants.symbolKeysPad
+    
+    //if the ipad is too samll for numbers
+    letterKeys.removeFirst(1)
+    letterKeys[0].append("delete")
+    
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "1"]
+    // TODO: add "p" to rightKeyChar if has 4 rows
     rightKeyChars = []
     centralKeyChars = allKeys.filter { !leftKeyChars.contains($0) && !rightKeyChars.contains($0) }
   }

--- a/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
@@ -30,7 +30,8 @@ public enum PortugueseKeyboardConstants {
   ]
 
   static let letterKeysPad = [
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"],
+    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0","-", "=", "delete"],
+    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
     ["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"],
     ["shift", "z", "x", "c", "v", "b", "n", "m", "!", "?", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "undoArrow"
@@ -79,10 +80,16 @@ func getPTKeys() {
     letterKeys = PortugueseKeyboardConstants.letterKeysPad
     numberKeys = PortugueseKeyboardConstants.numberKeysPad
     symbolKeys = PortugueseKeyboardConstants.symbolKeysPad
+    
+    //if the ipad is too samll for numbers
+    letterKeys.removeFirst(1)
+    letterKeys[0].append("delete")
+    
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "1"]
     rightKeyChars = []
+    // TODO: add "p" to rightKeyChar if has 4 rows
     centralKeyChars = allKeys.filter { !leftKeyChars.contains($0) && !rightKeyChars.contains($0) }
   }
 

--- a/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
@@ -30,7 +30,8 @@ public enum RussianKeyboardConstants {
   ]
 
   static let letterKeysPad = [
-    ["й", "ц", "у", "к", "е", "н", "г", "ш", "щ", "з", "х", "delete"],
+    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0","-", "=", "delete"],
+    ["й", "ц", "у", "к", "е", "н", "г", "ш", "щ", "з", "х"],
     ["ф", "ы", "в", "а", "п", "р", "о", "л", "д", "ж", "э", "return"],
     ["shift", "я", "ч", "с", "м", "и", "т", "ь", "б", "ю", ".", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "undoArrow"
@@ -74,10 +75,16 @@ func getRUKeys() {
     letterKeys = RussianKeyboardConstants.letterKeysPad
     numberKeys = RussianKeyboardConstants.numberKeysPad
     symbolKeys = RussianKeyboardConstants.symbolKeysPad
+    
+    //if the ipad is too samll for numbers
+    letterKeys.removeFirst(1)
+    letterKeys[0].append("delete")
+    
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["й", "ф", "1", "@", "$"]
     rightKeyChars = []
+    // TODO: add "х" to rightKeyChar if has 4 rows
     centralKeyChars = allKeys.filter { !leftKeyChars.contains($0) && !rightKeyChars.contains($0) }
   }
 

--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -30,7 +30,8 @@ public enum SpanishKeyboardConstants {
   ]
 
   static let letterKeysPad = [
-    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "delete"],
+    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0","-", "=", "delete"],
+    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p"],
     ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ñ", "return"],
     ["shift", "y", "x", "c", "v", "b", "n", "m", ",", ".", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "undoArrow"
@@ -81,10 +82,16 @@ func getESKeys() {
     letterKeys = SpanishKeyboardConstants.letterKeysPad
     numberKeys = SpanishKeyboardConstants.numberKeysPad
     symbolKeys = SpanishKeyboardConstants.symbolKeysPad
+    
+    //if the ipad is too samll for numbers
+    letterKeys.removeFirst(1)
+    letterKeys[0].append("delete")
+    
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "a", "1", "@", "€"]
-    rightKeyChars = []
+    // TODO: add "p" to rightKeyChar if has 4 rows
+    rightKeyChars = [""]
     centralKeyChars = allKeys.filter { !leftKeyChars.contains($0) && !rightKeyChars.contains($0) }
   }
 

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -30,7 +30,8 @@ public enum SwedishKeyboardConstants {
   ]
 
   static let letterKeysPad = [
-    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "å", "delete"],
+    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0","-", "=", "delete"],
+    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "å"],
     ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "return"],
     ["shift", "y", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "undoArrow"
@@ -82,10 +83,16 @@ func getSVKeys() {
     letterKeys = SwedishKeyboardConstants.letterKeysPad
     numberKeys = SwedishKeyboardConstants.numberKeysPad
     symbolKeys = SwedishKeyboardConstants.symbolKeysPad
+    
+    //if the ipad is too samll for numbers
+    letterKeys.removeFirst(1)
+    letterKeys[0].append("delete")
+    
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "a", "1", "@", "€"]
     rightKeyChars = []
+    // TODO: add "å" to rightKeyChar if has 4 rows
     centralKeyChars = allKeys.filter { !leftKeyChars.contains($0) && !rightKeyChars.contains($0) }
   }
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀

If you're not already a member of our public Matrix community, please consider joining via the following link:
https://matrix.to/#/#scribe_community:matrix.org

It'd be great to have you!

Also if you're new to open source, check that the email you use for GitHub (https://github.com/settings/emails) is the same the one you have for git so you get credit for your contribution. You can see your git email by typing `git config user.email` and set it globally with `git config --global user.email "your_email@email.com"`.
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [ ] below with checked ones [x] accordingly. -->

- [x ] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [ ] I have updated the [CHANGELOG](https://github.com/scribe-org/Scribe-iOS/blob/main/CHANGELOG.md) with a description of my changes for the upcoming release (if necessary) <!-- ... or I'll send a commit with this now 🙃 -->

---

### Description

<!--
Added a numbers row to the keyboard for iPad along with some logic on getting rid of the extra row if the screen is too small.

I tested by first leaving the extra row in to ensure that the numbers were showing up, then implemented the logic to ignore the new row and checked again to make sure it appeared how it did before.
-->

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #33 
