### PR TITLE
Move cursor for separated verbs

### DIFF
--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
@@ -221,7 +221,6 @@ func returnConjugation(keyPressed: UIButton, requestedForm: String) {
   if wordPressed == invalidCommandMsg {
     proxy.insertText("")
   } else if formsDisplayDimensions == .view3x2 {
-//    if deConjugationState != .indicativePerfect {
       let query = "SELECT * FROM verbs WHERE verb = ?"
       let args = [verbToConjugate]
       let outputCols = [requestedForm]
@@ -232,14 +231,6 @@ func returnConjugation(keyPressed: UIButton, requestedForm: String) {
       } else {
         proxy.insertText(wordToReturn + " ")
       }
- /*   } else {
-      let query = "SELECT * FROM verbs WHERE verb = ?"
-      let args = [verbToConjugate]
-      let outputCols = ["pastParticiple"]
-      wordToReturn = queryDBRow(query: query, outputCols: outputCols, args: args)[0]
-
-      proxy.insertText(wordToReturn + " ")
-    } */
   } else if formsDisplayDimensions == .view2x2 {
     let query = "SELECT * FROM verbs WHERE verb = ?"
     let args = [verbToConjugate]

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
@@ -221,7 +221,7 @@ func returnConjugation(keyPressed: UIButton, requestedForm: String) {
   if wordPressed == invalidCommandMsg {
     proxy.insertText("")
   } else if formsDisplayDimensions == .view3x2 {
-    if deConjugationState != .indicativePerfect {
+//    if deConjugationState != .indicativePerfect {
       let query = "SELECT * FROM verbs WHERE verb = ?"
       let args = [verbToConjugate]
       let outputCols = [requestedForm]
@@ -232,14 +232,14 @@ func returnConjugation(keyPressed: UIButton, requestedForm: String) {
       } else {
         proxy.insertText(wordToReturn + " ")
       }
-    } else {
+ /*   } else {
       let query = "SELECT * FROM verbs WHERE verb = ?"
       let args = [verbToConjugate]
       let outputCols = ["pastParticiple"]
       wordToReturn = queryDBRow(query: query, outputCols: outputCols, args: args)[0]
 
       proxy.insertText(wordToReturn + " ")
-    }
+    } */
   } else if formsDisplayDimensions == .view2x2 {
     let query = "SELECT * FROM verbs WHERE verb = ?"
     let args = [verbToConjugate]
@@ -250,6 +250,12 @@ func returnConjugation(keyPressed: UIButton, requestedForm: String) {
       proxy.insertText(wordToReturn.capitalized + " ")
     } else {
       proxy.insertText(wordToReturn + " ")
+    }
+  }
+  if controllerLanguage == "German" {
+    let components = wordToReturn.components(separatedBy: " ")
+    if components.count == 2 {
+      proxy.adjustTextPosition(byCharacterOffset: (components[1].count + 1) * -1)
     }
   }
   autoActionState = .suggest


### PR DESCRIPTION
### Contributor checklist

<!-- Please replace the empty checkboxes [ ] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [X] I have updated the [CHANGELOG](https://github.com/scribe-org/Scribe-iOS/blob/main/CHANGELOG.md) with a description of my changes for the upcoming release (if necessary) <!-- ... or I'll send a commit with this now 🙃 -->

---

### Description

Moves cursor in between verb + prefix (for verbs with sep. prefixes) or verb + participle (for perf. ind.) after selecting word in conj. menu.
To this end, selecting a verb in perf. ind. now writes verb + part. instead of just part.
Tested manually.

### Related issue

- #155
