### PR TITLE
feat: saving user preference on emoji autosuggest based on menu

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,9 @@ Thank you in advance for your contributions!
 
 # Data edits [`⇧`](#contents)
 
+> [!NOTE]\
+> Please see the [Wikidata and Scribe Guide](https://github.com/scribe-org/Organization/blob/main/WIKIDATAGUIDE.md) for an overview of [Wikidata](https://www.wikidata.org/) and how Scribe uses it.
+
 Scribe does not accept direct edits to the grammar JSON files as they are sourced from [Wikidata](https://www.wikidata.org/). Edits can be discussed and the [Scribe-Data](https://github.com/scribe-org/Scribe-Data) queries will be changed and ran before an update. If there is a problem with one of the files, then the fix should be made on [Wikidata](https://www.wikidata.org/) and not on Scribe. Feel free to let us know that edits have been made by [opening a data issue](https://github.com/scribe-org/Scribe-iOS/issues/new?assignees=&labels=data&template=data_wikidata.yml) or contacting us in the [issues for Scribe-Data](https://github.com/scribe-org/Scribe-Data/issues) and we'll be happy to integrate them!
 
 <a id="localization"></a>

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -430,7 +430,9 @@ class KeyboardViewController: UIInputViewController {
         }
 
         // Disable the third auto action button if we'll have emoji suggestions.
-        getEmojiAutoSuggestions(for: currentPrefix)
+        if emojiAutosuggestIsEnabled() {
+          getEmojiAutoSuggestions(for: currentPrefix)
+        }
       } else {
         getDefaultAutosuggestions()
       }
@@ -577,7 +579,9 @@ class KeyboardViewController: UIInputViewController {
     }
 
     // Disable the third auto action button if we'll have emoji suggestions.
-    getEmojiAutoSuggestions(for: prefix)
+    if emojiAutosuggestIsEnabled() {
+      getEmojiAutoSuggestions(for: prefix)
+    }
   }
 
   /// Sets up command buttons to execute autocomplete and autosuggest.
@@ -2008,11 +2012,8 @@ class KeyboardViewController: UIInputViewController {
   
   func setCommaAndPeriodKeysConditionally() {
     let langCode = languagesAbbrDict[controllerLanguage] ?? "unknown"
-    
     let userDefaults = UserDefaults(suiteName: "group.scribe.userDefaultsContainer")!
-    
     let dictionaryKey = langCode + "CommaAndPeriod"
-    
     let letterKeysHaveCommaPeriod = userDefaults.bool(forKey: dictionaryKey)
     
     if letterKeysHaveCommaPeriod {
@@ -2020,6 +2021,14 @@ class KeyboardViewController: UIInputViewController {
     } else {
       letterKeys[3] = ["123", "selectKeyboard", "space", "return"]
     }
+  }
+  
+  func emojiAutosuggestIsEnabled() -> Bool {
+    let langCode = languagesAbbrDict[controllerLanguage] ?? "unknown"
+    let userDefaults = UserDefaults(suiteName: "group.scribe.userDefaultsContainer")!
+    let dictionaryKey = langCode + "EmojiAutosuggest"
+    
+    return userDefaults.bool(forKey: dictionaryKey)
   }
 
   // MARK: Button Actions

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 [![license](https://img.shields.io/github/license/scribe-org/Scribe-iOS.svg?label=%20)](https://github.com/scribe-org/Scribe-iOS/blob/main/LICENSE.txt)
 [![coc](https://img.shields.io/badge/Contributor%20Covenant-ff69b4.svg)](https://github.com/scribe-org/Scribe-iOS/blob/main/.github/CODE_OF_CONDUCT.md)
 [![mastodon](https://img.shields.io/badge/Mastodon-6364FF.svg?logo=mastodon&logoColor=ffffff)](https://wikis.world/@scribe)
-[![twitter](https://img.shields.io/badge/Twitter-1DA1F2.svg?logo=twitter&logoColor=ffffff)](https://twitter.com/scribe_org)
 [![matrix](https://img.shields.io/badge/Matrix-000000.svg?logo=matrix&logoColor=ffffff)](https://matrix.to/#/#scribe_community:matrix.org)
 
 <a href='https://apps.apple.com/app/scribe-language-keyboards/id1596613886'><img alt='Available on the App Store' src='https://raw.githubusercontent.com/scribe-org/Scribe-iOS/main/.github/resources/images/app_store_badge.png' height='60px'/></a>

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ The Scribe road map can be followed in the organization's [project board](https:
 
 ### Data Edits [`⇧`](#contents)
 
+> [!NOTE]\
+> Please see the [Wikidata and Scribe Guide](https://github.com/scribe-org/Organization/blob/main/WIKIDATAGUIDE.md) for an overview of [Wikidata](https://www.wikidata.org/) and how Scribe uses it.
+
 Scribe does not accept direct edits to the grammar JSON files as they are sourced from [Wikidata](https://www.wikidata.org/). Edits can be discussed and the [Scribe-Data](https://github.com/scribe-org/Scribe-Data) queries will be changed and ran before an update. If there is a problem with one of the files, then the fix should be made on [Wikidata](https://www.wikidata.org/) and not on Scribe. Feel free to let us know that edits have been made by [opening a data issue](https://github.com/scribe-org/Scribe-iOS/issues/new?assignees=&labels=data&template=data_wikidata.yml) or contacting us in the [issues for Scribe-Data](https://github.com/scribe-org/Scribe-Data/issues) and we'll be happy to integrate them!
 
 ### Designs [`⇧`](#contents)

--- a/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
+++ b/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
@@ -65,10 +65,20 @@ class InfoChildTableViewCell: UITableViewCell {
     switch togglePurpose {
     case .toggleCommaAndPeriod:
       let dictionaryKey = languageCode + "CommaAndPeriod"
-      toggleSwitch.isOn = userDefaults.bool(forKey: dictionaryKey)
+      if let toggleValue = userDefaults.object(forKey: dictionaryKey) as? Bool {
+        toggleSwitch.isOn = toggleValue
+      } else {
+        /// Default value
+        toggleSwitch.isOn = false
+      }
     case .autosuggestEmojis:
       let dictionaryKey = languageCode + "EmojiAutosuggest"
-      toggleSwitch.isOn = userDefaults.bool(forKey: dictionaryKey)
+      if let toggleValue = userDefaults.object(forKey: dictionaryKey) as? Bool {
+        toggleSwitch.isOn = toggleValue
+      } else {
+        /// Default value
+        toggleSwitch.isOn = true
+      }
     case .none: break
     }
   }

--- a/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
+++ b/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
@@ -52,7 +52,9 @@ class InfoChildTableViewCell: UITableViewCell {
     case .toggleCommaAndPeriod:
       let dictionaryKey = languageCode + "CommaAndPeriod"
       userDefaults.setValue(toggleSwitch.isOn, forKey: dictionaryKey)
-    case .autosuggestEmojis: break
+    case .autosuggestEmojis:
+      let dictionaryKey = languageCode + "EmojiAutosuggest"
+      userDefaults.setValue(toggleSwitch.isOn, forKey: dictionaryKey)
     case .none: break
     }
 
@@ -64,7 +66,9 @@ class InfoChildTableViewCell: UITableViewCell {
     case .toggleCommaAndPeriod:
       let dictionaryKey = languageCode + "CommaAndPeriod"
       toggleSwitch.isOn = userDefaults.bool(forKey: dictionaryKey)
-    case .autosuggestEmojis: break
+    case .autosuggestEmojis:
+      let dictionaryKey = languageCode + "EmojiAutosuggest"
+      toggleSwitch.isOn = userDefaults.bool(forKey: dictionaryKey)
     case .none: break
     }
   }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Following up on issue #310, this PR adds the functionality for emoji autosuggest menu item. Changes include:
- Adding the required reference in the userDefaults
- Function to check if enabled in KeyboardViewController

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #311 

Hey @andrewtavis, I tested this with most of the cases where emojis would be suggested. Seems to work so far. Let me know if you come across a case where the emojis are showing despite the menu item. Probably missing a condition in that case but currently I think all cases should be covered.
