### PR TITLE
Set light text in light mode in Settings and About screens

### DIFF
--- a/Scribe/Info.plist
+++ b/Scribe/Info.plist
@@ -28,6 +28,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
@@ -42,5 +44,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 </dict>
 </plist>

--- a/Scribe/InstallationTab/InstallationVC.swift
+++ b/Scribe/InstallationTab/InstallationVC.swift
@@ -59,11 +59,6 @@ class InstallationVC: UIViewController {
     set { self.orientations = newValue }
   }
 
-  // The app screen is white content on blue, so match the status bar.
-  override var preferredStatusBarStyle: UIStatusBarStyle {
-    return .lightContent
-  }
-
   /// Sets the top icon for the app screen given the device to assure that it's oriented correctly to its background.
   func setTopIcon() {
     if DeviceType.isPhone {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

This PR sets light text in light mode in the Settings and About screens. Changes are:
- Info.plist:
    - Set `UIStatusBarStyle` to *UIStatusBarStyleLightContent*. This sets the light text in the status bar for the entire app.
    - Set `UIViewControllerBasedStatusBarAppearance` to *NO*. This prevents the status bar appearance to change within a screen.
 - InstallationVC.swift: remove the override of the var `preferredStatusBarStyle`

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #353 
