### PR TITLE
Automatically add new issues to Scribe-Board - Scribe-iOS repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug report
 description: Report a bug to help us improve Scribe-iOS.
 labels: ["bug"]
-projects: ["orgs/scribe-org/projects/1"]
+projects: ["scribe-org/1"]
 body:
   - type: checkboxes
     id: new-bug

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: 🐞 Bug report
 description: Report a bug to help us improve Scribe-iOS.
 labels: ["bug"]
+projects: ["projects/1"]
 body:
   - type: checkboxes
     id: new-bug

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug report
 description: Report a bug to help us improve Scribe-iOS.
 labels: ["bug"]
-projects: ["projects/1"]
+projects: ["orgs/scribe-org/projects/1"]
 body:
   - type: checkboxes
     id: new-bug

--- a/.github/ISSUE_TEMPLATE/data_wikidata.yml
+++ b/.github/ISSUE_TEMPLATE/data_wikidata.yml
@@ -1,6 +1,7 @@
 name: 🗃️ Data and Wikidata
 description: Help Scribe bring open-source language data to your fingertips.
 labels: ["data"]
+projects: ["scribe-org/1"]
 body:
   - type: checkboxes
     id: terms

--- a/.github/ISSUE_TEMPLATE/design_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/design_improvement.yml
@@ -1,6 +1,7 @@
 name: 🎨 Design improvement
 description: Make a suggestion for Scribe's UX/UI designs.
 labels: ["design"]
+projects: ["scribe-org/1"]
 body:
   - type: checkboxes
     id: terms

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: ✨ Feature request
 description: Have a new idea or feature for Scribe-iOS? Please suggest!
 labels: ["feature"]
+projects: ["scribe-org/1"]
 body:
   - type: checkboxes
     id: terms

--- a/.github/ISSUE_TEMPLATE/localization.yml
+++ b/.github/ISSUE_TEMPLATE/localization.yml
@@ -1,6 +1,7 @@
 name: 🌐 Localization
 description: Report issues or offer help for Scribe localizations.
 labels: ["localization"]
+projects: ["scribe-org/1"]
 body:
   - type: checkboxes
     id: terms

--- a/.github/ISSUE_TEMPLATE/new_keyboard.yml
+++ b/.github/ISSUE_TEMPLATE/new_keyboard.yml
@@ -1,6 +1,7 @@
 name: ⌨️ New keyboard
 description: Suggest a new language keyboard for Scribe!
 labels: ["new keyboard"]
+projects: ["scribe-org/1"]
 title: Add <language> keyboard
 body:
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,5 +1,6 @@
 name: ❓ Questions and everything else
 description: We'd love to hear from you!
+projects: ["scribe-org/1"]
 body:
   - type: checkboxes
     id: terms

--- a/.github/workflows/pr_maintainer_checklist.yaml
+++ b/.github/workflows/pr_maintainer_checklist.yaml
@@ -30,6 +30,6 @@ jobs:
 
             - [ ] The commit messages for the remote branch should be checked to make sure the contributor's email is set up correctly so that they receive credit for their contribution
               - The contributor's name and icon in remote commits should be the same as what appears in the PR
-              - If there's a mismatch, the contributor needs to make sure that the [email they use for GitHub](https://github.com/settings/emails) matches what they have for `git config user.email` in their local activist repo
+              - If there's a mismatch, the contributor needs to make sure that the [email they use for GitHub](https://github.com/settings/emails) matches what they have for `git config user.email` in their local Scribe-iOS repo
 
             - [ ] The [CHANGELOG](https://github.com/scribe-org/Scribe-iOS/blob/main/CHANGELOG.md) has been updated with a description of the changes for the upcoming release (if necessary)


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

A quick PR for automatically adding new issues to the scribe board project. Done by editing the .yml files for issue templates and including the project in them.

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #355 
