### PR TITLE
fix: Swapped the Y and Z keys which were in the wrong places on the s…

### DIFF
--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -32,9 +32,9 @@ public enum SpanishKeyboardConstants {
   // iPad keyboard layouts.
   static let letterKeysPad = [
     ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
-    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "delete"],
+    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"],
     ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ñ", "return"],
-    ["shift", "y", "x", "c", "v", "b", "n", "m", ",", ".", "shift"],
+    ["shift", "z", "x", "c", "v", "b", "n", "m", ",", ".", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "undo"
   ]
 


### PR DESCRIPTION
…Spanish keyboard in ESInterfaceVariables.swift lines 35 and 37

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
- Swapped the y and z variables in the spanish keyboard so they're in the correct places on the keyboard. 
- It was tested on the xcode simulator of an ipad.
### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #363
