### PR TITLE
Removing multiple delete keys on IPad

### DIFF
--- a/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
@@ -104,7 +104,6 @@ func getENKeys() {
 
     // If the iPad is too small to have a numbers row.
     letterKeys.removeFirst(1)
-    letterKeys[0].append("delete")
 
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 

--- a/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
@@ -102,7 +102,6 @@ func getFRKeys() {
 
     // If the iPad is too small to have a numbers row.
     letterKeys.removeFirst(1)
-    letterKeys[0].append("delete")
 
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 

--- a/Keyboards/LanguageKeyboards/French/FR-QWERTYInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FR-QWERTYInterfaceVariables.swift
@@ -100,7 +100,6 @@ func getFRQWERTYKeys() {
 
     // If the iPad is too small to have a numbers row.
     letterKeys.removeFirst(1)
-    letterKeys[0].append("delete")
 
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 

--- a/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
@@ -105,7 +105,6 @@ func getDEKeys() {
 
     // If the iPad is too small to have a numbers row.
     letterKeys.removeFirst(1)
-    letterKeys[0].append("delete")
 
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 

--- a/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
@@ -102,7 +102,6 @@ func getITKeys() {
 
     // If the iPad is too small to have a numbers row.
     letterKeys.removeFirst(1)
-    letterKeys[0].append("delete")
 
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 

--- a/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
@@ -101,7 +101,6 @@ func getPTKeys() {
 
     // If the iPad is too small to have a numbers row.
     letterKeys.removeFirst(1)
-    letterKeys[0].append("delete")
 
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 

--- a/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
@@ -96,7 +96,6 @@ func getRUKeys() {
 
     // If the iPad is too small to have a numbers row.
     letterKeys.removeFirst(1)
-    letterKeys[0].append("delete")
 
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 

--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -103,7 +103,6 @@ func getESKeys() {
 
     // If the iPad is too small to have a numbers row.
     letterKeys.removeFirst(1)
-    letterKeys[0].append("delete")
 
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -104,7 +104,6 @@ func getSVKeys() {
 
     // If the iPad is too small to have a numbers row.
     letterKeys.removeFirst(1)
-    letterKeys[0].append("delete")
 
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

- As shown in the related issue, the current version of Scribe-iOS appends an extra delete key within each languages interface, specifically for IPad. The solution proposed in this PR removes said append in each interface.

- Testing for this change was done on an emulator for IPad and IPad Mini using Xcode.

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #366 
