### PR TITLE
Menu item to disable accent characters on keyboard letter keys

### DIFF
--- a/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
@@ -14,6 +14,13 @@ public enum GermanKeyboardConstants {
     ["shift", "y", "x", "c", "v", "b", "n", "m", "delete"],
     ["123", "selectKeyboard", "space", "return"], // "undo"
   ]
+  
+  static let letterKeysPhoneDisableAccents = [
+    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p"],
+    ["a", "s", "d", "f", "g", "h", "j", "k", "l"],
+    ["shift", "y", "x", "c", "v", "b", "n", "m", "delete"],
+    ["123", "selectKeyboard", "space", "return"], // "undo"
+  ]
 
   static let numberKeysPhone = [
     ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
@@ -34,6 +41,14 @@ public enum GermanKeyboardConstants {
     ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
     ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "ü", "delete"],
     ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "return"],
+    ["shift", "y", "x", "c", "v", "b", "n", "m", ",", ".", "ß", "shift"],
+    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "undo"
+  ]
+  
+  static let letterKeysPadDisableAccents = [
+    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
+    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "delete"],
+    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"],
     ["shift", "y", "x", "c", "v", "b", "n", "m", ",", ".", "ß", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "undo"
   ]
@@ -60,6 +75,14 @@ public enum GermanKeyboardConstants {
     ["shift", "<", "y", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
+  
+  static let letterKeysPadExpandedDisableAccents = [
+    ["^", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "ß", "´", "delete"],
+    ["indent", "q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "+", "*"],
+    ["uppercase", "a", "s", "d", "f", "g", "h", "j", "k", "l", "#", "return"],
+    ["shift", "<", "y", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
+    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
+  ]
 
   static let symbolKeysPadExpanded = [
     ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
@@ -75,10 +98,13 @@ public enum GermanKeyboardConstants {
   static let keysWithAlternatesRight = ["i", "o", "u", "l", "n"]
 
   static let aAlternateKeys = ["à", "á", "â", "æ", "ã", "å", "ā", "ą"]
+  static let aAlternateKeysDisableAccents = ["à", "á", "â", "æ", "ã", "å", "ā", "ą", "ä"]
   static let eAlternateKeys = ["é", "è", "ê", "ë", "ė", "ę"]
   static let iAlternateKeys = ["ì", "ī", "í", "î", "ï"]
   static let oAlternateKeys = ["ō", "ø", "œ", "õ", "ó", "ò", "ô"]
+  static let oAlternateKeysDisableAccents = ["ō", "ø", "œ", "õ", "ó", "ò", "ô", "ö"]
   static let uAlternateKeys = ["ū", "ú", "ù", "û"]
+  static let uAlternateKeysDisableAccents = ["ū", "ú", "ù", "û", "ü"]
   static let yAlternateKeys = ["ÿ"]
   static let cAlternateKeys = ["ç", "ć", "č"]
   static let lAlternateKeys = ["ł"]
@@ -89,17 +115,31 @@ public enum GermanKeyboardConstants {
 
 /// Gets the keys for the German keyboard.
 func getDEKeys() {
+  let userDefaults = UserDefaults(suiteName: "group.scribe.userDefaultsContainer")!
+  
   if DeviceType.isPhone {
-    letterKeys = GermanKeyboardConstants.letterKeysPhone
+    if userDefaults.bool(forKey: "deAccentCharacters") {
+      letterKeys = GermanKeyboardConstants.letterKeysPhoneDisableAccents
+    } else {
+      letterKeys = GermanKeyboardConstants.letterKeysPhone
+    }
     numberKeys = GermanKeyboardConstants.numberKeysPhone
     symbolKeys = GermanKeyboardConstants.symbolKeysPhone
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "a", "1", "-", "[", "_"]
-    rightKeyChars = ["ü", "ä", "0", "\"", "=", "·"]
+    if userDefaults.bool(forKey: "deAccentCharacters") {
+      rightKeyChars = ["p", "l", "0", "\"", "=", "·"]
+    } else {
+      rightKeyChars = ["ü", "ä", "0", "\"", "=", "·"]
+    }
     centralKeyChars = allKeys.filter { !leftKeyChars.contains($0) && !rightKeyChars.contains($0) }
   } else {
-    letterKeys = GermanKeyboardConstants.letterKeysPad
+    if userDefaults.bool(forKey: "deAccentCharacters") {
+    letterKeys = GermanKeyboardConstants.letterKeysPadDisableAccents
+    } else {
+      letterKeys = GermanKeyboardConstants.letterKeysPad
+    }
     numberKeys = GermanKeyboardConstants.numberKeysPad
     symbolKeys = GermanKeyboardConstants.symbolKeysPad
 
@@ -118,17 +158,23 @@ func getDEKeys() {
   keysWithAlternates = GermanKeyboardConstants.keysWithAlternates
   keysWithAlternatesLeft = GermanKeyboardConstants.keysWithAlternatesLeft
   keysWithAlternatesRight = GermanKeyboardConstants.keysWithAlternatesRight
-  aAlternateKeys = GermanKeyboardConstants.aAlternateKeys
   eAlternateKeys = GermanKeyboardConstants.eAlternateKeys
   iAlternateKeys = GermanKeyboardConstants.iAlternateKeys
-  oAlternateKeys = GermanKeyboardConstants.oAlternateKeys
-  uAlternateKeys = GermanKeyboardConstants.uAlternateKeys
   yAlternateKeys = GermanKeyboardConstants.yAlternateKeys
   sAlternateKeys = GermanKeyboardConstants.sAlternateKeys
   lAlternateKeys = GermanKeyboardConstants.lAlternateKeys
   zAlternateKeys = GermanKeyboardConstants.zAlternateKeys
   cAlternateKeys = GermanKeyboardConstants.cAlternateKeys
   nAlternateKeys = GermanKeyboardConstants.nAlternateKeys
+  if userDefaults.bool(forKey: "deAccentCharacters") {
+    aAlternateKeys = GermanKeyboardConstants.aAlternateKeysDisableAccents
+    oAlternateKeys = GermanKeyboardConstants.oAlternateKeysDisableAccents
+    uAlternateKeys = GermanKeyboardConstants.uAlternateKeysDisableAccents
+  } else {
+    aAlternateKeys = GermanKeyboardConstants.aAlternateKeys
+    oAlternateKeys = GermanKeyboardConstants.oAlternateKeys
+    uAlternateKeys = GermanKeyboardConstants.uAlternateKeys
+  }
 }
 
 /// Provides the German keyboard layout.

--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -14,6 +14,13 @@ public enum SpanishKeyboardConstants {
     ["shift", "z", "x", "c", "v", "b", "n", "m", "delete"],
     ["123", "selectKeyboard", "space", "return"], // "undo"
   ]
+  
+  static let letterKeysPhoneDisableAccents = [
+    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
+    ["a", "s", "d", "f", "g", "h", "j", "k", "l"],
+    ["shift", "z", "x", "c", "v", "b", "n", "m", "delete"],
+    ["123", "selectKeyboard", "space", "return"], // "undo"
+  ]
 
   static let numberKeysPhone = [
     ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
@@ -34,6 +41,14 @@ public enum SpanishKeyboardConstants {
     ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
     ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"],
     ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ñ", "return"],
+    ["shift", "z", "x", "c", "v", "b", "n", "m", ",", ".", "shift"],
+    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "undo"
+  ]
+  
+  static let letterKeysPadDisableAccents = [
+    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
+    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"],
+    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"],
     ["shift", "z", "x", "c", "v", "b", "n", "m", ",", ".", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "undo"
   ]
@@ -60,6 +75,14 @@ public enum SpanishKeyboardConstants {
     ["shift", "|", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
+  
+  static let letterKeysPadExpandedDisableAccents = [
+    ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "'", "¿", "delete"],
+    ["indent", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "'", "+", "*"],
+    ["uppercase", "a", "s", "d", "f", "g", "h", "j", "k", "l", "{", "}", "return"],
+    ["shift", "|", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
+    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
+  ]
 
   static let symbolKeysPadExpanded = [
     ["§", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
@@ -82,22 +105,37 @@ public enum SpanishKeyboardConstants {
   static let cAlternateKeys = ["ç", "ć", "č"]
   static let dAlternateKeys = ["đ"]
   static let nAlternateKeys = ["ń"]
+  static let nAlternateKeysDisableAccents = ["ń","ñ"]
   static let sAlternateKeys = ["š"]
 }
 
 /// Gets the keys for the Spanish keyboard.
 func getESKeys() {
+  let userDefaults = UserDefaults(suiteName: "group.scribe.userDefaultsContainer")!
+  
   if DeviceType.isPhone {
-    letterKeys = SpanishKeyboardConstants.letterKeysPhone
+    if userDefaults.bool(forKey: "esAccentCharacters") {
+      letterKeys = SpanishKeyboardConstants.letterKeysPhoneDisableAccents
+    } else {
+      letterKeys = SpanishKeyboardConstants.letterKeysPhone
+    }
     numberKeys = SpanishKeyboardConstants.numberKeysPhone
     symbolKeys = SpanishKeyboardConstants.symbolKeysPhone
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "a", "1", "-", "[", "_"]
-    rightKeyChars = ["p", "ñ", "0", "\"", "=", "·"]
+    if userDefaults.bool(forKey: "esAccentCharacters") {
+      rightKeyChars = ["p", "l", "0", "\"", "=", "·"]
+    } else {
+      rightKeyChars = ["p", "ñ", "0", "\"", "=", "·"]
+    }
     centralKeyChars = allKeys.filter { !leftKeyChars.contains($0) && !rightKeyChars.contains($0) }
   } else {
-    letterKeys = SpanishKeyboardConstants.letterKeysPad
+    if userDefaults.bool(forKey: "esAccentCharacters") {
+      letterKeys = SpanishKeyboardConstants.letterKeysPadDisableAccents
+    } else {
+      letterKeys = SpanishKeyboardConstants.letterKeysPad
+    }
     numberKeys = SpanishKeyboardConstants.numberKeysPad
     symbolKeys = SpanishKeyboardConstants.symbolKeysPad
 
@@ -124,7 +162,11 @@ func getESKeys() {
   sAlternateKeys = SpanishKeyboardConstants.sAlternateKeys
   dAlternateKeys = SpanishKeyboardConstants.dAlternateKeys
   cAlternateKeys = SpanishKeyboardConstants.cAlternateKeys
-  nAlternateKeys = SpanishKeyboardConstants.nAlternateKeys
+  if userDefaults.bool(forKey: "esAccentCharacters") {
+    nAlternateKeys = SpanishKeyboardConstants.nAlternateKeysDisableAccents
+  } else {
+    nAlternateKeys = SpanishKeyboardConstants.nAlternateKeys
+  }
 }
 
 /// Provides the Spanish keyboard layout.

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -14,6 +14,13 @@ public enum SwedishKeyboardConstants {
     ["shift", "y", "x", "c", "v", "b", "n", "m", "delete"],
     ["123", "selectKeyboard", "space", "return"], // "undo"
   ]
+  
+  static let letterKeysPhoneDisableAccents = [
+    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p"],
+    ["a", "s", "d", "f", "g", "h", "j", "k", "l"],
+    ["shift", "y", "x", "c", "v", "b", "n", "m", "delete"],
+    ["123", "selectKeyboard", "space", "return"], // "undo"
+  ]
 
   static let numberKeysPhone = [
     ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
@@ -34,6 +41,14 @@ public enum SwedishKeyboardConstants {
     ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
     ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "å", "delete"],
     ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "return"],
+    ["shift", "y", "x", "c", "v", "b", "n", "m", ",", ".", "?", "shift"],
+    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "undo"
+  ]
+  
+  static let letterKeysPadDisableAccents = [
+    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
+    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "delete"],
+    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"],
     ["shift", "y", "x", "c", "v", "b", "n", "m", ",", ".", "?", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "undo"
   ]
@@ -60,6 +75,14 @@ public enum SwedishKeyboardConstants {
     ["shift", "<", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
+  
+  static let letterKeysPadExpandedDisableAccents = [
+    ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "+", "'", "delete"],
+    ["indent", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "^", "*"],
+    ["uppercase", "a", "s", "d", "f", "g", "h", "j", "k", "l", "'", "return"],
+    ["shift", "<", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
+    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
+  ]
 
   static let symbolKeysPadExpanded = [
     ["§", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
@@ -71,13 +94,17 @@ public enum SwedishKeyboardConstants {
 
   // Alternate key vars.
   static let keysWithAlternates = ["a", "e", "i", "o", "u", "ä", "ö", "c", "n", "s"]
+  static let keysWithAlernatesDisableAccents = ["a", "e", "i", "o", "u", "c", "n", "s"]
   static let keysWithAlternatesLeft = ["a", "e", "c", "s"]
   static let keysWithAlternatesRight = ["i", "o", "u", "ä", "ö", "n"]
+  static let keysWithAlternatesRightDisableAccents = ["i", "o", "u", "n"]
 
   static let aAlternateKeys = ["á", "à", "â", "ã", "ā"]
+  static let aAlternateKeysDisableAccents = ["á", "à", "â", "ã", "ā", "å"]
   static let eAlternateKeys = ["é", "ë", "è", "ê", "ẽ", "ē", "ę"]
   static let iAlternateKeys = ["ī", "î", "í", "ï", "ì", "ĩ"]
   static let oAlternateKeys = ["ō", "õ", "ô", "ò", "ó", "œ"]
+  static let oAlternateKeysDisableAccents = ["ō", "õ", "ô", "ò", "ó", "œ","ö","ø"]
   static let uAlternateKeys = ["û", "ú", "ü", "ù", "ũ", "ū"]
   static let äAlternateKeys = ["æ"]
   static let öAlternateKeys = ["ø"]
@@ -88,17 +115,31 @@ public enum SwedishKeyboardConstants {
 
 /// Gets the keys for the Swedish keyboard.
 func getSVKeys() {
+  let userDefaults = UserDefaults(suiteName: "group.scribe.userDefaultsContainer")!
+  
   if DeviceType.isPhone {
-    letterKeys = SwedishKeyboardConstants.letterKeysPhone
+    if userDefaults.bool(forKey: "svAccentCharacters") {
+      letterKeys = SwedishKeyboardConstants.letterKeysPhoneDisableAccents
+    } else {
+      letterKeys = SwedishKeyboardConstants.letterKeysPhone
+    }
     numberKeys = SwedishKeyboardConstants.numberKeysPhone
     symbolKeys = SwedishKeyboardConstants.symbolKeysPhone
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "a", "1", "-", "[", "_"]
-    rightKeyChars = ["å", "ä", "0", "\"", "=", "·"]
+    if userDefaults.bool(forKey: "svAccentCharacters") {
+      rightKeyChars = ["p", "l", "0", "\"", "=", "·"]
+    } else {
+      rightKeyChars = ["å", "ä", "0", "\"", "=", "·"]
+    }
     centralKeyChars = allKeys.filter { !leftKeyChars.contains($0) && !rightKeyChars.contains($0) }
   } else {
-    letterKeys = SwedishKeyboardConstants.letterKeysPad
+      if userDefaults.bool(forKey: "svAccentCharacters") {
+      letterKeys = SwedishKeyboardConstants.letterKeysPadDisableAccents
+    } else {
+      letterKeys = SwedishKeyboardConstants.letterKeysPad
+    }
     numberKeys = SwedishKeyboardConstants.numberKeysPad
     symbolKeys = SwedishKeyboardConstants.symbolKeysPad
 
@@ -114,16 +155,23 @@ func getSVKeys() {
     centralKeyChars = allKeys.filter { !leftKeyChars.contains($0) && !rightKeyChars.contains($0) }
   }
 
-  keysWithAlternates = SwedishKeyboardConstants.keysWithAlternates
+  if userDefaults.bool(forKey: "svAccentCharacters") {
+    keysWithAlternates = SwedishKeyboardConstants.keysWithAlernatesDisableAccents
+    keysWithAlternatesRight = SwedishKeyboardConstants.keysWithAlternatesRightDisableAccents
+    aAlternateKeys = SwedishKeyboardConstants.aAlternateKeysDisableAccents
+    oAlternateKeys = SwedishKeyboardConstants.oAlternateKeysDisableAccents
+  } else {
+    keysWithAlternates = SwedishKeyboardConstants.keysWithAlternates
+    keysWithAlternatesRight = SwedishKeyboardConstants.keysWithAlternatesRight
+    aAlternateKeys = SwedishKeyboardConstants.aAlternateKeys
+    oAlternateKeys = SwedishKeyboardConstants.oAlternateKeys
+    äAlternateKeys = SwedishKeyboardConstants.äAlternateKeys
+    öAlternateKeys = SwedishKeyboardConstants.öAlternateKeys
+  }
   keysWithAlternatesLeft = SwedishKeyboardConstants.keysWithAlternatesLeft
-  keysWithAlternatesRight = SwedishKeyboardConstants.keysWithAlternatesRight
-  aAlternateKeys = SwedishKeyboardConstants.aAlternateKeys
   eAlternateKeys = SwedishKeyboardConstants.eAlternateKeys
   iAlternateKeys = SwedishKeyboardConstants.iAlternateKeys
-  oAlternateKeys = SwedishKeyboardConstants.oAlternateKeys
   uAlternateKeys = SwedishKeyboardConstants.uAlternateKeys
-  äAlternateKeys = SwedishKeyboardConstants.äAlternateKeys
-  öAlternateKeys = SwedishKeyboardConstants.öAlternateKeys
   sAlternateKeys = SwedishKeyboardConstants.sAlternateKeys
   cAlternateKeys = SwedishKeyboardConstants.cAlternateKeys
   nAlternateKeys = SwedishKeyboardConstants.nAlternateKeys

--- a/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
+++ b/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
@@ -55,6 +55,9 @@ class InfoChildTableViewCell: UITableViewCell {
     case .autosuggestEmojis:
       let dictionaryKey = languageCode + "EmojiAutosuggest"
       userDefaults.setValue(toggleSwitch.isOn, forKey: dictionaryKey)
+    case .toggleAccentCharacters:
+      let dictionaryKey = languageCode + "AccentCharacters"
+      userDefaults.setValue(toggleSwitch.isOn, forKey: dictionaryKey)
     case .none: break
     }
 
@@ -78,6 +81,14 @@ class InfoChildTableViewCell: UITableViewCell {
       } else {
         /// Default value
         toggleSwitch.isOn = true
+      }
+    case .toggleAccentCharacters:
+      let dictionaryKey = languageCode + "AccentCharacters"
+      if let toggleValue = userDefaults.object(forKey: dictionaryKey) as? Bool {
+        toggleSwitch.isOn = toggleValue
+      } else {
+        /// Default value
+        toggleSwitch.isOn = false
       }
     case .none: break
     }

--- a/Scribe/ParentTableCellModel.swift
+++ b/Scribe/ParentTableCellModel.swift
@@ -37,6 +37,7 @@ enum SectionState: Equatable {
 enum UserInteractiveState {
   case toggleCommaAndPeriod
   case autosuggestEmojis
+  case toggleAccentCharacters
   case none
 }
 

--- a/Scribe/SettingsTab/SettingsTableData.swift
+++ b/Scribe/SettingsTab/SettingsTableData.swift
@@ -32,6 +32,12 @@ struct SettingsTableData {
           hasToggle: true,
           sectionState: .none(.toggleCommaAndPeriod)
         ),
+        Section(
+          sectionTitle: "Disable accent characters",
+          imageString: "info.circle",
+          hasToggle: true,
+          sectionState: .none(.toggleAccentCharacters)
+        ),
       ],
       hasDynamicData: nil
     ),


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

- Adding a toggle to the layout settings to disable accents from Spanish, Swedish, and German keyboards.

- Testing for this change was done on the XCode simulator for iPhone 15 Pro

### Related issue

- #339 
