### PR TITLE
[#371] Add functionality for new keyboard expanded layout

### DIFF
--- a/Keyboards/InterfaceConstants.swift
+++ b/Keyboards/InterfaceConstants.swift
@@ -1,0 +1,9 @@
+//
+//  Scribe
+//
+
+struct SpecialKeys {
+
+  static let indent = "indent"
+  static let capsLock = "capslock"
+}

--- a/Keyboards/KeyboardsBase/InterfaceVariables.swift
+++ b/Keyboards/KeyboardsBase/InterfaceVariables.swift
@@ -16,7 +16,7 @@ var keyboard = [[String]]()
 var usingExpandedKeyboard = false
 var allKeys = [String]()
 let specialKeys = [
-  "shift", "delete", "ABC", "АБВ", "123", "#+=", "selectKeyboard", "space", "return", ".?123", "hideKeyboard",
+  SpecialKeys.indent, SpecialKeys.capsLock, "shift", "delete", "ABC", "АБВ", "123", "#+=", "selectKeyboard", "space", "return", ".?123", "hideKeyboard",
 ]
 var allNonSpecialKeys = [String]()
 var keyboardHeight: CGFloat!
@@ -51,11 +51,17 @@ enum KeyboardState {
 /// What the keyboard state is in regards to the shift key.
 /// - normal: not capitalized
 /// - shift: capitalized
-/// - caps: caps-lock
 enum ShiftButtonState {
   case normal
   case shift
-  case caps
+}
+
+/// What the keyboard state is in regards to the all caps key.
+/// - normal: not capitalized
+/// - locked: caps-lock
+enum CapsLockButtonState {
+  case normal
+  case locked
 }
 
 /// States of the keyboard corresponding to which commands the user is executing.
@@ -89,6 +95,7 @@ enum ConjViewShiftButtonsState {
 // Baseline state variables.
 var keyboardState: KeyboardState = .letters
 var shiftButtonState: ShiftButtonState = .normal
+var capsLockButtonState: CapsLockButtonState = .normal
 var commandState: CommandState = .idle
 var autoActionState: AutoActionState = .suggest
 var conjViewShiftButtonsState: ConjViewShiftButtonsState = .bothInactive

--- a/Keyboards/KeyboardsBase/KeyAnimation.swift
+++ b/Keyboards/KeyboardsBase/KeyAnimation.swift
@@ -319,7 +319,7 @@ func setPhoneKeyPopCharSize(char: String) {
       keyPopChar.font = .systemFont(ofSize: letterKeyWidth / 1.15)
       keyHoldPopChar.font = .systemFont(ofSize: letterKeyWidth / 1.15)
     }
-  } else if shiftButtonState == .shift || shiftButtonState == .caps {
+  } else if shiftButtonState == .shift || capsLockButtonState == .locked {
     if isLandscapeView {
       keyPopChar.font = .systemFont(ofSize: letterKeyWidth / 2.15)
       keyHoldPopChar.font = .systemFont(ofSize: letterKeyWidth / 2.15)
@@ -351,7 +351,7 @@ func setPadKeyPopCharSize(char: String) {
       keyPopChar.font = .systemFont(ofSize: letterKeyWidth / 2.5)
       keyHoldPopChar.font = .systemFont(ofSize: letterKeyWidth / 2.5)
     }
-  } else if keyboardState == .letters, shiftButtonState == .shift || shiftButtonState == .caps {
+  } else if keyboardState == .letters, shiftButtonState == .shift || capsLockButtonState == .locked {
     if isLandscapeView {
       keyPopChar.font = .systemFont(ofSize: letterKeyWidth / 2.5)
       keyHoldPopChar.font = .systemFont(ofSize: letterKeyWidth / 2.5)

--- a/Keyboards/KeyboardsBase/KeyboardKeys.swift
+++ b/Keyboards/KeyboardsBase/KeyboardKeys.swift
@@ -285,7 +285,7 @@ class KeyboardKey: UIButton {
     }
   }
 
-  /// Adjusts the style of the button based on different states
+  /// Adjusts the style of the button based on different states.
   func adjustButtonStyle() {
     guard let isSpecial = layer.value(forKey: "isSpecial") as? Bool else { return }
 
@@ -308,7 +308,13 @@ class KeyboardKey: UIButton {
     case "shift":
       if shiftButtonState == .shift {
         backgroundColor = keyPressedColor
+
         styleIconBtn(btn: self, color: UIColor.label, iconName: "shift.fill")
+      } else if DeviceType.isPhone && capsLockButtonState == .locked {
+        // We need to style the SHIFT button instead of the CAPSLOCK since the keyboard is smaller
+        backgroundColor = keyPressedColor
+
+        styleIconBtn(btn: self, color: UIColor.label, iconName: "capslock.fill")
       } else {
         backgroundColor = specialKeyColor
       }
@@ -317,6 +323,8 @@ class KeyboardKey: UIButton {
       if [.translate, .conjugate, .plural].contains(commandState) {
         // Color the return key depending on if it's being used as enter for commands.
         backgroundColor = commandKeyColor
+      } else {
+        backgroundColor = specialKeyColor
       }
 
     default:

--- a/Keyboards/KeyboardsBase/KeyboardKeys.swift
+++ b/Keyboards/KeyboardsBase/KeyboardKeys.swift
@@ -65,7 +65,7 @@ class KeyboardKey: UIButton {
     } else {
       capsKey = key
     }
-    let keyToDisplay = shiftButtonState == .normal ? key : capsKey
+    let keyToDisplay = shiftButtonState == .shift || capsLockButtonState == .locked ? capsKey : key
     setTitleColor(keyCharColor, for: .normal)
     layer.setValue(key, forKey: "original")
     layer.setValue(keyToDisplay, forKey: "keyToDisplay")
@@ -256,22 +256,14 @@ class KeyboardKey: UIButton {
     if key == "ABC" || key == "АБВ" {
       layer.setValue(true, forKey: "isSpecial")
       widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1).isActive = true
-    } else if key == "delete"
-      || key == "#+="
-      || key == "shift"
-      || key == "selectKeyboard"
-    {
+    } else if ["delete", "#+=", "shift", "selectKeyboard", SpecialKeys.indent, SpecialKeys.capsLock].contains(key) {
       layer.setValue(true, forKey: "isSpecial")
       widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1).isActive = true
-    } else if key == "123"
-      || key == ".?123"
-      || key == "return"
-      || key == "hideKeyboard"
-    {
+    } else if ["123", ".?123", "return", "hideKeyboard"].contains(key) {
       if key == "return"
-        && (controllerLanguage == "Portuguese" || controllerLanguage == "Italian" || commandState == .translate)
-        && row == 1
-        && DeviceType.isPad
+          && (controllerLanguage == "Portuguese" || controllerLanguage == "Italian" || commandState == .translate)
+          && row == 1
+          && DeviceType.isPad
       {
         layer.setValue(true, forKey: "isSpecial")
         widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.5).isActive = true
@@ -291,25 +283,46 @@ class KeyboardKey: UIButton {
     } else if DeviceType.isPad {
       adjustPadKeyWidth()
     }
+  }
 
+  /// Adjusts the style of the button based on different states
+  func adjustButtonStyle() {
     guard let isSpecial = layer.value(forKey: "isSpecial") as? Bool else { return }
 
-    if key == "shift" {
-      // Switch the shift key icon given its state.
+    switch key {
+    case SpecialKeys.indent:
+      backgroundColor = specialKeyColor
+
+    case SpecialKeys.capsLock:
+      switch capsLockButtonState {
+
+      case .normal:
+        backgroundColor = specialKeyColor
+        styleIconBtn(btn: self, color: UIColor.label, iconName: "capslock")
+
+      case .locked:
+        backgroundColor = keyPressedColor
+        styleIconBtn(btn: self, color: UIColor.label, iconName: "capslock.fill")
+      }
+
+    case "shift":
       if shiftButtonState == .shift {
         backgroundColor = keyPressedColor
         styleIconBtn(btn: self, color: UIColor.label, iconName: "shift.fill")
-      } else if shiftButtonState == .caps {
-        backgroundColor = keyPressedColor
-        styleIconBtn(btn: self, color: UIColor.label, iconName: "capslock.fill")
       } else {
         backgroundColor = specialKeyColor
       }
-    } else if key == "return" && [.translate, .conjugate, .plural].contains(commandState) {
-      // Color the return key depending on if it's being used as enter for commands.
-      backgroundColor = commandKeyColor
-    } else if isSpecial {
-      backgroundColor = specialKeyColor
+
+    case "return":
+      if [.translate, .conjugate, .plural].contains(commandState) {
+        // Color the return key depending on if it's being used as enter for commands.
+        backgroundColor = commandKeyColor
+      }
+
+    default:
+      if isSpecial {
+        backgroundColor = specialKeyColor
+      }
     }
   }
 }

--- a/Keyboards/KeyboardsBase/KeyboardStyling.swift
+++ b/Keyboards/KeyboardsBase/KeyboardStyling.swift
@@ -40,7 +40,9 @@ var keysThatAreSlightlyLarger = [
   "chevron.right",
   "shift",
   "shift.fill",
+  "capslock",
   "capslock.fill",
+  "arrow.forward.to.line",
   "arrowtriangle.right.fill",
 ]
 

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Annotate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Annotate.swift
@@ -229,18 +229,23 @@ func selectedWordAnnotation(KVC: KeyboardViewController) {
 /// - Parameters
 ///   - KVC: the keyboard view controller.
 func typedWordAnnotation(KVC: KeyboardViewController) {
-  if proxy.documentContextBeforeInput?.count != 0 {
-    wordsTyped = proxy.documentContextBeforeInput!.components(separatedBy: " ")
-    let lastWordTyped = wordsTyped.secondToLast()
-    if !languagesWithCapitalizedNouns.contains(controllerLanguage) {
-      wordToCheck = lastWordTyped!.lowercased()
-    } else {
-      wordToCheck = lastWordTyped!
-    }
-    wordAnnotation(wordToAnnotate: wordToCheck, KVC: KVC)
-  } else {
+  guard let documentContextBeforeInput = proxy.documentContextBeforeInput, !documentContextBeforeInput.isEmpty else {
     return
   }
+
+  wordsTyped = documentContextBeforeInput.components(separatedBy: " ")
+
+  guard let lastWordTyped = wordsTyped.secondToLast() else {
+    return
+  }
+  
+  if !languagesWithCapitalizedNouns.contains(controllerLanguage) {
+    wordToCheck = lastWordTyped.lowercased()
+  } else {
+    wordToCheck = lastWordTyped
+  }
+
+  wordAnnotation(wordToAnnotate: wordToCheck, KVC: KVC)
 }
 
 /// Annotates nouns during autocomplete and autosuggest.

--- a/Keyboards/LanguageKeyboards/Danish/DAInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Danish/DAInterfaceVariables.swift
@@ -55,16 +55,16 @@ public enum DanishKeyboardConstants {
   // Expanded iPad keyboard layouts for wider devices.
   static let letterKeysPadExpanded = [
     ["$", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "+", "'", "delete"],
-    ["indent", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å", "@", "*"],
-    ["uppercase", "a", "s", "d", "f", "g", "h", "j", "k", "l", "æ", "ø", "'", "return"],
+    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å", "@", "*"],
+    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "æ", "ø", "'", "return"],
     ["shift", "<", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
 
   static let symbolKeysPadExpanded = [
     ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    ["indent", "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|"],
-    ["uppercase", "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
+    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|"],
+    [SpecialKeys.capsLock, "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
     ["shift", "...", ".", ",", "?", "!", "'", "\"", "_", "€"], // "redo"
     ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"], // "microphone", "scribble"
   ]

--- a/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
@@ -55,16 +55,16 @@ public enum EnglishKeyboardConstants {
   // Expanded iPad keyboard layouts for wider devices.
   static let letterKeysPadExpanded = [
     ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "delete"],
-    ["indent", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]", "\\"],
-    ["uppercase", "a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'", "return"],
+    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]", "\\"],
+    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'", "return"],
     ["shift", "z", "x", "c", "v", "b", "n", "m", ",", ".", "/", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
 
   static let symbolKeysPadExpanded = [
     ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    ["indent", "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "~"],
-    ["uppercase", "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "return"], // "undo"
+    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "~"],
+    [SpecialKeys.capsLock, "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "return"], // "undo"
     ["shift", "...", ".", ",", "?", "!", "'", "\"", "_", "€"], // "redo"
     ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"], // "microphone", "scribble"
   ]

--- a/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
@@ -55,16 +55,16 @@ public enum FrenchKeyboardConstants {
   // Expanded iPad keyboard layouts for wider devices.
   static let letterKeysPadExpanded = [
     ["@", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "°", "–", "delete"],
-    ["indent", "a", "z", "e", "r", "t", "y", "u", "i", "o", "p", "^", "$", "*"],
-    ["uppercase", "q", "s", "d", "f", "g", "h", "j", "k", "l", "m", "€", "%", "return"],
+    [SpecialKeys.indent, "a", "z", "e", "r", "t", "y", "u", "i", "o", "p", "^", "$", "*"],
+    [SpecialKeys.capsLock, "q", "s", "d", "f", "g", "h", "j", "k", "l", "m", "€", "%", "return"],
     ["shift", "/", "w", "x", "c", "v", "b", "n", ",", ".", "<", ">", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
 
   static let symbolKeysPadExpanded = [
     ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    ["indent", "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "§"],
-    ["uppercase", "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
+    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "§"],
+    [SpecialKeys.capsLock, "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
     ["shift", "...", ".", ",", "?", "!", "'", "\"", "_", "€"], // "redo"
     ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"], // "microphone", "scribble"
   ]

--- a/Keyboards/LanguageKeyboards/French/FR-QWERTYInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FR-QWERTYInterfaceVariables.swift
@@ -53,16 +53,16 @@ public enum FrenchQWERTYKeyboardConstants {
   // Expanded iPad keyboard layouts for wider devices.
   static let letterKeysPadExpanded = [
     ["/", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "delete"],
-    ["indent", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "^", "ç", ":"],
-    ["uppercase", "a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "è", "à", "return"],
+    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "^", "ç", ":"],
+    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "è", "à", "return"],
     ["shift", "ù", "z", "x", "c", "v", "b", "n", "m", ",", ".", "é", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
 
   static let symbolKeysPadExpanded = [
     ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    ["indent", "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "~"],
-    ["uppercase", "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
+    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "~"],
+    [SpecialKeys.capsLock, "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
     ["shift", "...", ".", ",", "?", "!", "'", "\"", "_", "€"], // "redo"
     ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"], // "microphone", "scribble"
   ]

--- a/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
@@ -70,24 +70,24 @@ public enum GermanKeyboardConstants {
   // Expanded iPad keyboard layouts for wider devices.
   static let letterKeysPadExpanded = [
     ["^", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "ß", "´", "delete"],
-    ["indent", "q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "ü", "+", "*"],
-    ["uppercase", "a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "#", "return"],
+    [SpecialKeys.indent, "q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "ü", "+", "*"],
+    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "#", "return"],
     ["shift", "<", "y", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
 
   static let letterKeysPadExpandedDisableAccents = [
     ["^", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "ß", "´", "delete"],
-    ["indent", "q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "+", "*"],
-    ["uppercase", "a", "s", "d", "f", "g", "h", "j", "k", "l", "#", "return"],
+    [SpecialKeys.indent, "q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "+", "*"],
+    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "#", "return"],
     ["shift", "<", "y", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
 
   static let symbolKeysPadExpanded = [
     ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    ["indent", "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "§"],
-    ["uppercase", "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
+    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "§"],
+    [SpecialKeys.capsLock, "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
     ["shift", "...", ".", ",", "?", "!", "'", "\"", "_", "€"], // "redo"
     ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"], // "microphone", "scribble"
   ]

--- a/Keyboards/LanguageKeyboards/Hebrew/HEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Hebrew/HEInterfaceVariables.swift
@@ -55,16 +55,16 @@ public enum HebrewKeyboardConstants {
   // Expanded iPad keyboard layouts for wider devices.
   static let letterKeysPadExpanded = [
     ["§", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "delete"],
-    ["indent", "/", "'", "פ", "ם", "ן", "ו", "ט", "א", "ר", "ק", "[", "]", "+"],
-    ["uppercase", "ף", "ך", "ל", "ח", "י", "ע", "כ", "ג", "ד", "ש", ",", "\"", "return"], // "accent"
+    [SpecialKeys.indent, "/", "'", "פ", "ם", "ן", "ו", "ט", "א", "ר", "ק", "[", "]", "+"],
+    [SpecialKeys.capsLock, "ף", "ך", "ל", "ח", "י", "ע", "כ", "ג", "ד", "ש", ",", "\"", "return"], // "accent"
     ["shift", ";", "ץ", "ת", "צ", "מ", "נ", "ה", "ב", "ס", "ז", ".", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
 
   static let symbolKeysPadExpanded = [
     ["±", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    ["indent", "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|"],
-    ["uppercase", "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
+    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|"],
+    [SpecialKeys.capsLock, "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
     ["shift", "...", ".", ",", "?", "!", "'", "\"", "_", "€"], // "redo"
     ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"], // "microphone", "scribble"
   ]

--- a/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
@@ -55,16 +55,16 @@ public enum ItalianKeyboardConstants {
   // Expanded iPad keyboard layouts for wider devices.
   static let letterKeysPadExpanded = [
     ["\\", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "'", "ì", "delete"],
-    ["indent", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "è", "+", "*"],
-    ["uppercase", "a", "s", "d", "f", "g", "h", "j", "k", "l", "ò", "à", "ù", "return"],
+    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "è", "+", "*"],
+    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "ò", "à", "ù", "return"],
     ["shift", "<", "z", "x", "c", "v", "b", "n", "m", ",", ".", ">", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
 
   static let symbolKeysPadExpanded = [
     ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    ["indent", "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "§"],
-    ["uppercase", "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
+    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "§"],
+    [SpecialKeys.capsLock, "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
     ["shift", "...", ".", ",", "?", "!", "'", "\"", "_", "€"], // "shift"
     ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"], // "microphone", "scribble"
   ]

--- a/Keyboards/LanguageKeyboards/Norwegian/NBInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Norwegian/NBInterfaceVariables.swift
@@ -55,16 +55,16 @@ public enum NorwegianBokmålKeyboardConstants {
   // Expanded iPad keyboard layouts for wider devices.
   static let letterKeysPadExpanded = [
     ["'", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "+", "'", "delete"],
-    ["indent", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å", "^", "*"],
-    ["uppercase", "a", "s", "d", "f", "g", "h", "j", "k", "l", "ø", "æ", "@", "return"],
+    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å", "^", "*"],
+    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "ø", "æ", "@", "return"],
     ["shift", "<", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
 
   static let symbolKeysPadExpanded = [
     ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    ["indent", "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|"],
-    ["uppercase", "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
+    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|"],
+    [SpecialKeys.capsLock, "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
     ["shift", "...", ".", ",", "?", "!", "'", "\"", "_", "€"], // "redo"
     ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"], // "microphone", "scribble"
   ]

--- a/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
@@ -55,16 +55,16 @@ public enum PortugueseKeyboardConstants {
   // Expanded iPad keyboard layouts for wider devices.
   static let letterKeysPadExpanded = [
     ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "delete"],
-    ["indent", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]", "\\"],
-    ["uppercase", "a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'", "return"],
+    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]", "\\"],
+    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'", "return"],
     ["shift", "z", "x", "c", "v", "b", "n", "m", "<", ">", "/", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
 
   static let symbolKeysPadExpanded = [
     ["§", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    ["indent", "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "~"],
-    ["uppercase", "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "return"], // "undo"
+    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "~"],
+    [SpecialKeys.capsLock, "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "return"], // "undo"
     ["shift", "...", ".", ",", "?", "!", "'", "\"", "_", "€"], // "redo"
     ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"], // "microphone", "scribble"
   ]

--- a/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
@@ -55,16 +55,16 @@ public enum RussianKeyboardConstants {
   // Expanded iPad keyboard layouts for wider devices.
   static let letterKeysPadExpanded = [
     ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "delete"],
-    ["indent", "й", "ц", "у", "к", "е", "н", "г", "ш", "щ", "з", "х", "ъ", "+"],
-    ["uppercase", "ф", "ы", "в", "а", "п", "р", "о", "л", "д", "ж", "э", "ё", "return"],
+    [SpecialKeys.indent, "й", "ц", "у", "к", "е", "н", "г", "ш", "щ", "з", "х", "ъ", "+"],
+    [SpecialKeys.capsLock, "ф", "ы", "в", "а", "п", "р", "о", "л", "д", "ж", "э", "ё", "return"],
     ["shift", "[", "я", "ч", "с", "м", "и", "т", "ь", "б", "ю", "/", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
 
   static let symbolKeysPadExpanded = [
     ["§", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    ["indent", "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\\", "|", "₽"],
-    ["uppercase", "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
+    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\\", "|", "₽"],
+    [SpecialKeys.capsLock, "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
     ["shift", "...", ".", ",", "?", "!", "'", "\"", "_", "€"], // "redo"
     ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"], // "microphone", "scribble"
   ]

--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -70,24 +70,24 @@ public enum SpanishKeyboardConstants {
   // Expanded iPad keyboard layouts for wider devices.
   static let letterKeysPadExpanded = [
     ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "'", "¿", "delete"],
-    ["indent", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "'", "+", "*"],
-    ["uppercase", "a", "s", "d", "f", "g", "h", "j", "k", "l", "ñ", "{", "}", "return"],
+    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "'", "+", "*"],
+    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "ñ", "{", "}", "return"],
     ["shift", "|", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
 
   static let letterKeysPadExpandedDisableAccents = [
     ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "'", "¿", "delete"],
-    ["indent", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "'", "+", "*"],
-    ["uppercase", "a", "s", "d", "f", "g", "h", "j", "k", "l", "{", "}", "return"],
+    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "'", "+", "*"],
+    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "{", "}", "return"],
     ["shift", "|", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
 
   static let symbolKeysPadExpanded = [
     ["§", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    ["indent", "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|"],
-    ["uppercase", "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
+    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|"],
+    [SpecialKeys.capsLock, "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
     ["shift", "...", ".", ",", "?", "!", "'", "\"", "_", "€"], // "redo"
     ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"], // "microphone", "scribble"
   ]

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -70,24 +70,24 @@ public enum SwedishKeyboardConstants {
   // Expanded iPad keyboard layouts for wider devices.
   static let letterKeysPadExpanded = [
     ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "+", "'", "delete"],
-    ["indent", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å", "^", "*"],
-    ["uppercase", "a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "'", "return"],
+    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å", "^", "*"],
+    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "'", "return"],
     ["shift", "<", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
 
   static let letterKeysPadExpandedDisableAccents = [
     ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "+", "'", "delete"],
-    ["indent", "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "^", "*"],
-    ["uppercase", "a", "s", "d", "f", "g", "h", "j", "k", "l", "'", "return"],
+    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "^", "*"],
+    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "'", "return"],
     ["shift", "<", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
     ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"], // "microphone", "scribble"
   ]
 
   static let symbolKeysPadExpanded = [
     ["§", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    ["indent", "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|"],
-    ["uppercase", "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
+    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|"],
+    [SpecialKeys.capsLock, "-", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
     ["shift", "...", ".", ",", "?", "!", "'", "\"", "_", "€"], // "redo"
     ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"], // "microphone", "scribble"
   ]

--- a/Scribe.xcodeproj/project.pbxproj
+++ b/Scribe.xcodeproj/project.pbxproj
@@ -727,6 +727,18 @@
 		D1CDEDDC2A85AE9D00098546 /* NBInterfaceVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CDED802A85A12400098546 /* NBInterfaceVariables.swift */; };
 		D1F0367227AAE12200CD7921 /* InterfaceVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = D190B2492741B31F00705659 /* InterfaceVariables.swift */; };
 		D1F0367327AAE1B400CD7921 /* CommandVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = D190B2462741B24F00705659 /* CommandVariables.swift */; };
+		EDC364692AE408F20001E456 /* InterfaceConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC364682AE408F20001E456 /* InterfaceConstants.swift */; };
+		EDC3646A2AE408FA0001E456 /* InterfaceConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC364682AE408F20001E456 /* InterfaceConstants.swift */; };
+		EDC3646B2AE408FC0001E456 /* InterfaceConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC364682AE408F20001E456 /* InterfaceConstants.swift */; };
+		EDC3646C2AE408FC0001E456 /* InterfaceConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC364682AE408F20001E456 /* InterfaceConstants.swift */; };
+		EDC3646D2AE408FD0001E456 /* InterfaceConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC364682AE408F20001E456 /* InterfaceConstants.swift */; };
+		EDC3646E2AE408FE0001E456 /* InterfaceConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC364682AE408F20001E456 /* InterfaceConstants.swift */; };
+		EDC3646F2AE408FE0001E456 /* InterfaceConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC364682AE408F20001E456 /* InterfaceConstants.swift */; };
+		EDC364702AE408FE0001E456 /* InterfaceConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC364682AE408F20001E456 /* InterfaceConstants.swift */; };
+		EDC364712AE408FF0001E456 /* InterfaceConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC364682AE408F20001E456 /* InterfaceConstants.swift */; };
+		EDC364722AE408FF0001E456 /* InterfaceConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC364682AE408F20001E456 /* InterfaceConstants.swift */; };
+		EDC364732AE409000001E456 /* InterfaceConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC364682AE408F20001E456 /* InterfaceConstants.swift */; };
+		EDC364742AE409000001E456 /* InterfaceConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC364682AE408F20001E456 /* InterfaceConstants.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -955,6 +967,7 @@
 		D1CDED802A85A12400098546 /* NBInterfaceVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NBInterfaceVariables.swift; sourceTree = "<group>"; };
 		D1CDED822A85A12C00098546 /* NBCommandVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NBCommandVariables.swift; sourceTree = "<group>"; };
 		D1D8B2372AE4084D0070B817 /* Swedish.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Swedish.entitlements; sourceTree = "<group>"; };
+		EDC364682AE408F20001E456 /* InterfaceConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceConstants.swift; sourceTree = "<group>"; };
 		D1D8B2382AE408620070B817 /* Spanish.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Spanish.entitlements; sourceTree = "<group>"; };
 		D1D8B2392AE408720070B817 /* Russian.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Russian.entitlements; sourceTree = "<group>"; };
 		D1D8B23A2AE408850070B817 /* Portuguese.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Portuguese.entitlements; sourceTree = "<group>"; };
@@ -1459,6 +1472,7 @@
 			children = (
 				D190B2452741B1FE00705659 /* KeyboardsBase */,
 				D1CCA15B2742B9F700902744 /* LanguageKeyboards */,
+				EDC364682AE408F20001E456 /* InterfaceConstants.swift */,
 			);
 			path = Keyboards;
 			sourceTree = "<group>";
@@ -2022,6 +2036,7 @@
 				D1B0719727C63C9100FD7DBD /* KeyAnimation.swift in Sources */,
 				14AC56842A24AED3006B1DDF /* AboutViewController.swift in Sources */,
 				D171945527AF05D40038660B /* Extensions.swift in Sources */,
+				EDC364692AE408F20001E456 /* InterfaceConstants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2082,6 +2097,7 @@
 				D1B0719927C63CE600FD7DBD /* KeyAnimation.swift in Sources */,
 				D1CDEDB42A85AE8100098546 /* HECommandVariables.swift in Sources */,
 				D171940A27AECCE50038660B /* PTCommandVariables.swift in Sources */,
+				EDC364722AE408FF0001E456 /* InterfaceConstants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2142,6 +2158,7 @@
 				D1B0719827C63CE600FD7DBD /* KeyAnimation.swift in Sources */,
 				D1CDEDB32A85AE8100098546 /* HECommandVariables.swift in Sources */,
 				D171941927AECD070038660B /* ESCommandVariables.swift in Sources */,
+				EDC364732AE409000001E456 /* InterfaceConstants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2202,6 +2219,7 @@
 				D1B0719C27C63CE800FD7DBD /* KeyAnimation.swift in Sources */,
 				D1CDEDB82A85AE8300098546 /* HECommandVariables.swift in Sources */,
 				D171941B27AECD070038660B /* ESCommandVariables.swift in Sources */,
+				EDC3646E2AE408FE0001E456 /* InterfaceConstants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2262,6 +2280,7 @@
 				D1B0719D27C63CE800FD7DBD /* KeyAnimation.swift in Sources */,
 				D1CDEDB92A85AE8300098546 /* HECommandVariables.swift in Sources */,
 				D171941D27AECD070038660B /* ESCommandVariables.swift in Sources */,
+				EDC3646B2AE408FC0001E456 /* InterfaceConstants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2322,6 +2341,7 @@
 				D1B0719B27C63CE700FD7DBD /* KeyAnimation.swift in Sources */,
 				D1CDEDBB2A85AE8500098546 /* HECommandVariables.swift in Sources */,
 				D171941C27AECD070038660B /* ESCommandVariables.swift in Sources */,
+				EDC3646D2AE408FD0001E456 /* InterfaceConstants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2382,6 +2402,7 @@
 				D1B0719E27C63CE900FD7DBD /* KeyAnimation.swift in Sources */,
 				D1CDEDBA2A85AE8400098546 /* HECommandVariables.swift in Sources */,
 				D171941E27AECD070038660B /* ESCommandVariables.swift in Sources */,
+				EDC3646C2AE408FC0001E456 /* InterfaceConstants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2442,6 +2463,7 @@
 				D1AB5B4F29C757A100CCB0C1 /* ScribeKey.swift in Sources */,
 				D1CDEDB72A85AE8300098546 /* HECommandVariables.swift in Sources */,
 				D1AB5B5029C757A100CCB0C1 /* KeyAnimation.swift in Sources */,
+				EDC3646F2AE408FE0001E456 /* InterfaceConstants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2502,6 +2524,7 @@
 				D1AFDF2D29CA66D00033BF27 /* ScribeKey.swift in Sources */,
 				D1CDEDB22A85AE7F00098546 /* HECommandVariables.swift in Sources */,
 				D1AFDF2E29CA66D00033BF27 /* KeyAnimation.swift in Sources */,
+				EDC364742AE409000001E456 /* InterfaceConstants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2562,6 +2585,7 @@
 				D1AFDFAA29CA66F40033BF27 /* ScribeKey.swift in Sources */,
 				D1CDEDB12A85AE7E00098546 /* HECommandVariables.swift in Sources */,
 				D1AFDFAB29CA66F40033BF27 /* KeyAnimation.swift in Sources */,
+				EDC3646A2AE408FA0001E456 /* InterfaceConstants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2622,6 +2646,7 @@
 				D1AFE00029CA6E900033BF27 /* ScribeKey.swift in Sources */,
 				D1CDEDB52A85AE8200098546 /* HECommandVariables.swift in Sources */,
 				D1AFE00129CA6E900033BF27 /* KeyAnimation.swift in Sources */,
+				EDC364712AE408FF0001E456 /* InterfaceConstants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2682,6 +2707,7 @@
 				D1B81D4627BBB71C0085FE5E /* ScribeKey.swift in Sources */,
 				D1CDEDB62A85AE8200098546 /* HECommandVariables.swift in Sources */,
 				D1B0719A27C63CE600FD7DBD /* KeyAnimation.swift in Sources */,
+				EDC364702AE408FE0001E456 /* InterfaceConstants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This PR implements #371 by adding functionality for the new expanded layout that was introduced by #352.

The `indent` key is now fully functional as well as the `capslock` key.

#### Recordings

**Old design**

https://github.com/scribe-org/Scribe-iOS/assets/1595177/6a6765a9-b749-4554-a032-5fcba6e322dd

**New design**

https://github.com/scribe-org/Scribe-iOS/assets/1595177/4a0e4c1b-f187-4450-9976-7ad333543457

#### Screenshots

| Description | Screenshot |
|--------|--------|
| **New design (iPad)** | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-10-22 at 14 46 46](https://github.com/scribe-org/Scribe-iOS/assets/1595177/15fd622a-9106-4e93-bcf8-11465db63df3) |
| **Design on iPhone (no changes)** | ![Simulator Screenshot - iPhone 15 Pro - 2023-10-22 at 14 54 17](https://github.com/scribe-org/Scribe-iOS/assets/1595177/fe26bd51-a7fb-4251-9293-b4809c80daa6) |
| **Capslock** | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-10-22 at 14 46 53](https://github.com/scribe-org/Scribe-iOS/assets/1595177/f5ed8f09-d9c6-4ecb-bd1d-f34fe2f2ba74) |
| **Uppercased suggestion** | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-10-22 at 14 56 09](https://github.com/scribe-org/Scribe-iOS/assets/1595177/8d9ceb40-de43-48e8-bb78-e2d0f0db5836) |

### Related issue

- #352 