### PR TITLE
Fixes #380: Code quality improvement by replacing while with for loop

### DIFF
--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -403,9 +403,8 @@ class KeyboardViewController: UIInputViewController {
         let completionOptions = queryAutocompletions(word: currentPrefix)
 
         if completionOptions[0] != "" {
-          var i = 0
           if completionOptions.count <= 3 {
-            while i < completionOptions.count {
+            for i in 0 ..< completionOptions.count {
               if shiftButtonState == .shift {
                 completionWords[i] = completionOptions[i].capitalize()
               } else if capsLockButtonState == .locked {
@@ -419,10 +418,9 @@ class KeyboardViewController: UIInputViewController {
               } else {
                 completionWords[i] = completionOptions[i]
               }
-              i += 1
             }
           } else {
-            while i < 3 {
+            for i in 0 ..< 3 {
               if shiftButtonState == .shift {
                 completionWords[i] = completionOptions[i].capitalize()
               } else if capsLockButtonState == .locked {
@@ -436,7 +434,6 @@ class KeyboardViewController: UIInputViewController {
               } else {
                 completionWords[i] = completionOptions[i]
               }
-              i += 1
             }
           }
         }
@@ -460,9 +457,8 @@ class KeyboardViewController: UIInputViewController {
     let prefix = proxy.documentContextBeforeInput?.components(separatedBy: " ").secondToLast() ?? ""
 
     completionWords = [String]()
-    var i = 0
     let query = "SELECT * FROM verbs WHERE verb = ?"
-    while i < 3 {
+    for i in 0 ..< 3 {
       // Get conjugations of the preselected verbs.
       let args = [verbsAfterPronounsArray[i]]
       let outputCols = [pronounAutosuggestionTenses[prefix.lowercased()]!]
@@ -481,19 +477,17 @@ class KeyboardViewController: UIInputViewController {
       } else {
         completionWords.append(suggestion)
       }
-      i += 1
     }
   }
 
   /// Generates an array of three words that serve as baseline autosuggestions.
   func getDefaultAutosuggestions() {
-    var i = 0
     completionWords = [String]()
-    if allowUndo {
-      completionWords.append(previousWord)
-      i += 1
-    }
-    while i < 3 {
+    for i in 0 ..< 3 {
+      if (allowUndo) {
+        completionWords.append(previousWord)
+        continue
+      }
       if shiftButtonState == .shift {
         completionWords.append(baseAutosuggestions[i].capitalize())
       } else if capsLockButtonState == .locked {
@@ -501,7 +495,6 @@ class KeyboardViewController: UIInputViewController {
       } else {
         completionWords.append(baseAutosuggestions[i])
       }
-      i += 1
     }
   }
 
@@ -543,12 +536,11 @@ class KeyboardViewController: UIInputViewController {
       let suggestionsCapitalizedPrefix = queryDBRow(query: query, outputCols: outputCols, args: argsCapitalize)
       if suggestionsLowerCasePrefix[0] != "" {
         completionWords = [String]()
-        var i = 0
-        if allowUndo {
-          completionWords.append(previousWord)
-          i += 1
-        }
-        while i < 3 {
+        for i in 0 ..< 3 {
+          if (allowUndo) {
+            completionWords.append(previousWord)
+            continue
+          }
           if shiftButtonState == .shift {
             completionWords.append(suggestionsLowerCasePrefix[i].capitalize())
           } else if capsLockButtonState == .locked {
@@ -566,16 +558,14 @@ class KeyboardViewController: UIInputViewController {
               completionWords.append(suggestionsLowerCasePrefix[i])
             }
           }
-          i += 1
         }
       } else if suggestionsCapitalizedPrefix[0] != "" {
         completionWords = [String]()
-        var i = 0
-        if allowUndo {
-          completionWords.append(previousWord)
-          i += 1
-        }
-        while i < 3 {
+        for i in 0 ..< 3 {
+          if (allowUndo) {
+            completionWords.append(previousWord)
+            continue
+          }
           if shiftButtonState == .shift {
             completionWords.append(suggestionsCapitalizedPrefix[i].capitalize())
           } else if capsLockButtonState == .locked {
@@ -583,7 +573,6 @@ class KeyboardViewController: UIInputViewController {
           } else {
             completionWords.append(suggestionsCapitalizedPrefix[i])
           }
-          i += 1
         }
       } else {
         getDefaultAutosuggestions()


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
I have made a simple refactoring of the code to replace while with for loop as suggested previously by @flumaves. 
In order to replace the logic for i+=1 due to the allowUndo if clause, I have used the continue keyword to skip to 0th indexed element in the event allowUndo evaluates to true. 

### Testing code works: 
I have verified the new changes retain the same behaviour as previously.

I have also run the app in the simulator to ensure the keyboard view works as expected as shown in the attached screenshot.
![image](https://github.com/scribe-org/Scribe-iOS/assets/55353265/df1ee873-d550-4d12-a186-e755ff1a257e) 

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- Fixes #380

Please let me know if there are any changes for me to make. Hoping to be able to submit my first contribution to this project! 