### PR TITLE
Added copyright notice to all .swift files (#391)

### DIFF
--- a/Keyboards/InterfaceConstants.swift
+++ b/Keyboards/InterfaceConstants.swift
@@ -1,6 +1,5 @@
 /**
- * Constants for the Scribe keyboard interfaces
- *
+ * Constants for the Scribe keyboard interfaces.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/InterfaceConstants.swift
+++ b/Keyboards/InterfaceConstants.swift
@@ -1,8 +1,22 @@
-//
-//  Scribe
-//
-//  Constants for Scribe keyboard interfaces.
-//
+/**
+ * Constants for the Scribe keyboard interfaces
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 enum SpecialKeys {
   static let indent = "indent"

--- a/Keyboards/KeyboardsBase/Colors/ColorVariables.swift
+++ b/Keyboards/KeyboardsBase/Colors/ColorVariables.swift
@@ -1,8 +1,22 @@
-//
-//  ColorVariables.swift
-//
-//  Variables associated with coloration for Scribe.
-//
+/**
+ * Variables associated with coloration for scribe
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/Colors/ColorVariables.swift
+++ b/Keyboards/KeyboardsBase/Colors/ColorVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Variables associated with coloration for scribe
- *
+ * Variables associated with coloration for scribe.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/Colors/ColorVariables.swift
+++ b/Keyboards/KeyboardsBase/Colors/ColorVariables.swift
@@ -1,5 +1,5 @@
 /**
- * Variables associated with coloration for scribe.
+ * Variables associated with coloration for Scribe keyboards.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/Colors/ScribeColor.swift
+++ b/Keyboards/KeyboardsBase/Colors/ScribeColor.swift
@@ -1,6 +1,5 @@
 /**
- * Converts strings for colors into the corresponding color
- *
+ * Converts strings for colors into the corresponding color.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/Colors/ScribeColor.swift
+++ b/Keyboards/KeyboardsBase/Colors/ScribeColor.swift
@@ -1,6 +1,22 @@
-//
-//  ScribeColor.swift
-//
+/**
+ * Converts strings for colors into the corresponding color
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/Colors/UIColor+ScribeColors.swift
+++ b/Keyboards/KeyboardsBase/Colors/UIColor+ScribeColors.swift
@@ -1,6 +1,5 @@
 /**
- * Adds Scribe colors to the UIColor pool
- *
+ * Adds Scribe colors to the UIColor pool.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/Colors/UIColor+ScribeColors.swift
+++ b/Keyboards/KeyboardsBase/Colors/UIColor+ScribeColors.swift
@@ -1,6 +1,22 @@
-//
-//  UIColor+ScribeColors.swift
-//
+/**
+ * Adds Scribe colors to the UIColor pool
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/Extensions.swift
+++ b/Keyboards/KeyboardsBase/Extensions.swift
@@ -1,8 +1,22 @@
-//
-//  Extensions.swift
-//
-//  Extensions for Scribe keyboards.
-//
+/**
+ * Extensions for Scribe keyboards
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/Extensions.swift
+++ b/Keyboards/KeyboardsBase/Extensions.swift
@@ -1,6 +1,5 @@
 /**
- * Extensions for Scribe keyboards
- *
+ * Extensions for Scribe keyboards.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/InterfaceVariables.swift
+++ b/Keyboards/KeyboardsBase/InterfaceVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Variables associated with the base keyboard interface
- *
+ * Variables associated with the base keyboard interface.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/InterfaceVariables.swift
+++ b/Keyboards/KeyboardsBase/InterfaceVariables.swift
@@ -1,8 +1,22 @@
-//
-//  InterfaceVariables.swift
-//
-//  Variables associated with the base keyboard interface.
-//
+/**
+ * Variables associated with the base keyboard interface
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/KeyAltChars.swift
+++ b/Keyboards/KeyboardsBase/KeyAltChars.swift
@@ -1,6 +1,5 @@
 /**
- * Functions and variables to create alternate key views
- *
+ * Functions and variables to create alternate key views.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/KeyAltChars.swift
+++ b/Keyboards/KeyboardsBase/KeyAltChars.swift
@@ -1,8 +1,22 @@
-//
-//  KeyAltChars.swift
-//
-//  Functions and variables to create alternate key views.
-//
+/**
+ * Functions and variables to create alternate key views
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/KeyAnimation.swift
+++ b/Keyboards/KeyboardsBase/KeyAnimation.swift
@@ -1,6 +1,5 @@
 /**
- * Functions to animate key pressed with pop up characters
- *
+ * Functions to animate key pressed with pop up characters.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/KeyAnimation.swift
+++ b/Keyboards/KeyboardsBase/KeyAnimation.swift
@@ -1,5 +1,5 @@
 /**
- * Functions to animate key pressed with pop up characters.
+ * Functions to animate key presses with pop up characters.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/KeyAnimation.swift
+++ b/Keyboards/KeyboardsBase/KeyAnimation.swift
@@ -1,8 +1,22 @@
-//
-//  KeyAnimation.swift
-//
-//  Functions to animate key pressed with pop up characters.
-//
+/**
+ * Functions to animate key pressed with pop up characters
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/KeyboardKeys.swift
+++ b/Keyboards/KeyboardsBase/KeyboardKeys.swift
@@ -1,6 +1,5 @@
 /**
- * Classes and variables that define keys for Scribe keyboards
- *
+ * Classes and variables that define keys for Scribe keyboards.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/KeyboardKeys.swift
+++ b/Keyboards/KeyboardsBase/KeyboardKeys.swift
@@ -1,8 +1,22 @@
-//
-//  KeyboardKey.swift
-//
-//  Classes and variables that define keys for Scribe keyboards.
-//
+/**
+ * Classes and variables that define keys for Scribe keyboards
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/KeyboardStyling.swift
+++ b/Keyboards/KeyboardsBase/KeyboardStyling.swift
@@ -1,8 +1,22 @@
-//
-//  KeyboardStyling.swift
-//
-//  Functions to style keyboard elements.
-//
+/**
+ * Functions to style keyboard elements
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/KeyboardStyling.swift
+++ b/Keyboards/KeyboardsBase/KeyboardStyling.swift
@@ -1,6 +1,5 @@
 /**
- * Functions to style keyboard elements
- *
+ * Functions to style keyboard elements.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -1,5 +1,5 @@
 /**
- * Classes for the parent keyboard view controller that language keyboards inherit and keyboard keys..
+ * Classes for the parent keyboard view controller that language keyboards.
  *
  * Copyright (C) 2023 Scribe
  *
@@ -17,7 +17,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-              
 import GRDB
 import UIKit
 
@@ -207,10 +206,10 @@ class KeyboardViewController: UIInputViewController {
   /// - A call to loadKeys to reload the display after an orientation change
   override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
-    Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false) { (nil) in
+    Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false) { _ in
       self.updateViewConstraints()
     }
-    Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false) { (nil) in
+    Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false) { _ in
       isFirstKeyboardLoad = true
       self.loadKeys()
       isFirstKeyboardLoad = false
@@ -502,7 +501,7 @@ class KeyboardViewController: UIInputViewController {
   func getDefaultAutosuggestions() {
     completionWords = [String]()
     for i in 0 ..< 3 {
-      if (allowUndo) {
+      if allowUndo {
         completionWords.append(previousWord)
         continue
       }
@@ -555,7 +554,7 @@ class KeyboardViewController: UIInputViewController {
       if suggestionsLowerCasePrefix[0] != "" {
         completionWords = [String]()
         for i in 0 ..< 3 {
-          if (allowUndo) {
+          if allowUndo {
             completionWords.append(previousWord)
             continue
           }
@@ -580,7 +579,7 @@ class KeyboardViewController: UIInputViewController {
       } else if suggestionsCapitalizedPrefix[0] != "" {
         completionWords = [String]()
         for i in 0 ..< 3 {
-          if (allowUndo) {
+          if allowUndo {
             completionWords.append(previousWord)
             continue
           }

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -1,9 +1,24 @@
-//
-//  KeyboardViewController.swift
-//
-//  Classes for the parent keyboard view controller that language keyboards inherit and keyboard keys.
-//
+/**
+ * Classes for the parent keyboard view controller that language keyboards inherit and keyboard keys.
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
+              
 import GRDB
 import UIKit
 

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -1,6 +1,5 @@
 /**
- * Classes for the parent keyboard view controller that language keyboards inherit and keyboard keys.
- *
+ * Classes for the parent keyboard view controller that language keyboards inherit and keyboard keys..
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/LoadData.swift
+++ b/Keyboards/KeyboardsBase/LoadData.swift
@@ -1,8 +1,22 @@
-//
-//  LoadData.swift
-//
-//  Function for loading in data to the keyboards.
-//
+/**
+ * Function for loading in data to the keyboards
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import Foundation
 import GRDB

--- a/Keyboards/KeyboardsBase/LoadData.swift
+++ b/Keyboards/KeyboardsBase/LoadData.swift
@@ -1,6 +1,5 @@
 /**
- * Function for loading in data to the keyboards
- *
+ * Function for loading in data to the keyboards.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Annotate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Annotate.swift
@@ -1,6 +1,5 @@
 /**
- * Functions and elements that control word annotations
- *
+ * Functions and elements that control word annotations.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Annotate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Annotate.swift
@@ -1,8 +1,22 @@
-//
-//  Annotate.swift
-//
-//  Functions and elements that control word annotations.
-//
+/**
+ * Functions and elements that control word annotations
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
@@ -1,8 +1,22 @@
-//
-//  CommandBar.swift
-//
-//  Class defining the bar into which commands are typed.
-//
+/**
+ * Class defining the bar into which commands are typed
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
@@ -1,6 +1,5 @@
 /**
- * Class defining the bar into which commands are typed
- *
+ * Class defining the bar into which commands are typed.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
@@ -1,8 +1,22 @@
-//
-//  CommandVariables.swift
-//
-//  Variables associated with Scribe commands.
-//
+/**
+ * Variables associated with Scribe commands
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import GRDB
 import UIKit

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Variables associated with Scribe commands
- *
+ * Variables associated with Scribe commands.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
@@ -1,8 +1,22 @@
-//
-//  Conjugation.swift
-//
-//  Functions and elements that control the conjugation command.
-//
+/**
+ * Functions and elements that control the conjugation command
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
@@ -1,6 +1,5 @@
 /**
- * Functions and elements that control the conjugation command
- *
+ * Functions and elements that control the conjugation command.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Plural.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Plural.swift
@@ -1,6 +1,5 @@
 /**
- * Functions that control the plural command
- *
+ * Functions that control the plural command.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Plural.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Plural.swift
@@ -1,8 +1,22 @@
-//
-//  Plural.swift
-//
-//  Functions that control the plural command.
-//
+/**
+ * Functions that control the plural command
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/ScribeKey.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/ScribeKey.swift
@@ -1,6 +1,5 @@
 /**
- * Class defining the Scribe key that is used to access keyboard commands
- *
+ * Class defining the Scribe key that is used to access keyboard commands.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/ScribeKey.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/ScribeKey.swift
@@ -1,8 +1,22 @@
-//
-//  ScribeKey.swift
-//
-//  Class defining the Scribe key that is used to access keyboard commands.
-//
+/**
+ * Class defining the Scribe key that is used to access keyboard commands
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
@@ -1,6 +1,5 @@
 /**
- * Functions that control the translate command
- *
+ * Functions that control the translate command.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
@@ -1,8 +1,22 @@
-//
-//  Translate.swift
-//
-//  Functions that control the translate command.
-//
+/**
+ * Functions that control the translate command
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/ToolTip/Model/InformationToolTipData.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Model/InformationToolTipData.swift
@@ -1,6 +1,5 @@
 /**
- * Data used for tooltips
- *
+ * Data used for tooltips.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/ToolTip/Model/InformationToolTipData.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Model/InformationToolTipData.swift
@@ -1,6 +1,22 @@
-//
-//  InformationToolTipData.swift
-//
+/**
+ * Data used for tooltips
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import Foundation
 import UIKit

--- a/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewDatasource.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewDatasource.swift
@@ -1,6 +1,22 @@
-//
-//  ToolTipViewDatasource.swift
-//
+/**
+ * Creates tooltips to be used in the ToolTipView
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import Foundation
 

--- a/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewDatasource.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewDatasource.swift
@@ -1,6 +1,5 @@
 /**
- * Creates tooltips to be used in the ToolTipView
- *
+ * Creates tooltips to be used in the ToolTipView.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewTheme.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewTheme.swift
@@ -1,6 +1,5 @@
 /**
- * Attributes for tooltips
- *
+ * Attributes for tooltips.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewTheme.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewTheme.swift
@@ -1,6 +1,22 @@
-//
-//  ToolTipViewTheme.swift
-//
+/**
+ * Attributes for tooltips
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/ToolTip/Protocol/ToolTipViewDatasourceable.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Protocol/ToolTipViewDatasourceable.swift
@@ -1,7 +1,6 @@
 /**
- * Controls the ToolTipViewDatasourceable protocol
+ * Controls the ToolTipViewDatasourceable protocol.
  * 
- *
  * Copyright (C) 2023 Scribe
  *
  * This program is free software: you can redistribute it and/or modify

--- a/Keyboards/KeyboardsBase/ToolTip/Protocol/ToolTipViewDatasourceable.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Protocol/ToolTipViewDatasourceable.swift
@@ -1,6 +1,22 @@
-//
-//  ToolTipViewDatasourceable.swift
-//
+/**
+ * Controls the ToolTipViewDatasourceable protocol
+ * 
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import Foundation
 

--- a/Keyboards/KeyboardsBase/ToolTip/Protocol/ToolTipViewUpdatable.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Protocol/ToolTipViewUpdatable.swift
@@ -1,7 +1,6 @@
 /**
- * Controls the ToolTipViewUpdatable protocol
+ * Controls the ToolTipViewUpdatable protocol.
  * 
- *
  * Copyright (C) 2023 Scribe
  *
  * This program is free software: you can redistribute it and/or modify

--- a/Keyboards/KeyboardsBase/ToolTip/Protocol/ToolTipViewUpdatable.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Protocol/ToolTipViewUpdatable.swift
@@ -1,6 +1,22 @@
-//
-//  ToolTipViewUpdatable.swift
-//
+/**
+ * Controls the ToolTipViewUpdatable protocol
+ * 
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import Foundation
 

--- a/Keyboards/KeyboardsBase/ToolTip/Protocol/ViewThemeable.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Protocol/ViewThemeable.swift
@@ -1,6 +1,22 @@
-//
-//  ViewThemeable.swift
-//
+/**
+ * Controls the ViewThemeable protocol
+ * 
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/ToolTip/Protocol/ViewThemeable.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Protocol/ViewThemeable.swift
@@ -1,7 +1,6 @@
 /**
- * Controls the ViewThemeable protocol
+ * Controls the ViewThemeable protocol.
  * 
- *
  * Copyright (C) 2023 Scribe
  *
  * This program is free software: you can redistribute it and/or modify

--- a/Keyboards/KeyboardsBase/ToolTip/ToolTipView.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/ToolTipView.swift
@@ -1,6 +1,22 @@
-//
-//  ToolTipView.swift
-//
+/**
+ * The main file used to control tooltips
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/KeyboardsBase/ToolTip/ToolTipView.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/ToolTipView.swift
@@ -1,6 +1,5 @@
 /**
- * The main file used to control tooltips
- *
+ * The main file used to control tooltips.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/Utilities.swift
+++ b/Keyboards/KeyboardsBase/Utilities.swift
@@ -1,6 +1,5 @@
 /**
- * Simple utility functions for data extraction and language management
- *
+ * Simple utility functions for data extraction and language management.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/KeyboardsBase/Utilities.swift
+++ b/Keyboards/KeyboardsBase/Utilities.swift
@@ -1,8 +1,22 @@
-//
-//  Utilities.swift
-//
-//  Simple utility functions for data extraction and language management.
-//
+/**
+ * Simple utility functions for data extraction and language management
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 /// Returns the ISO code given a language.
 ///

--- a/Keyboards/LanguageKeyboards/Danish/DACommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Danish/DACommandVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Variables associated with commands for the Danish Scribe keyboard
- *
+ * Variables associated with commands for the Danish Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Danish/DACommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Danish/DACommandVariables.swift
@@ -1,8 +1,22 @@
-//
-//  DACommandVariables.swift
-//
-//  Variables associated with commands for the Danish Scribe keyboard.
-//
+/**
+ * Variables associated with commands for the Danish Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 func daSetConjugationLabels() {
   // Reset all form labels prior to assignment.

--- a/Keyboards/LanguageKeyboards/Danish/DAInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Danish/DAInterfaceVariables.swift
@@ -1,8 +1,22 @@
-//
-//  DAInterfaceVariables.swift
-//
-//  Constants and functions to load the Danish Scribe keyboard.
-//
+/**
+ * Constants and functions to load the Danish Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/LanguageKeyboards/Danish/DAInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Danish/DAInterfaceVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Constants and functions to load the Danish Scribe keyboard
- *
+ * Constants and functions to load the Danish Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Danish/DAKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Danish/DAKeyboardViewController.swift
@@ -1,6 +1,5 @@
 /**
- * Class for the Danish Scribe keybaord
- *
+ * Class for the Danish Scribe keybaord.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Danish/DAKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Danish/DAKeyboardViewController.swift
@@ -1,5 +1,21 @@
-//
-//  DAKeyboardViewController.swift
-//
+/**
+ * Class for the Danish Scribe keybaord
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 class DAKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/Danish/DAKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Danish/DAKeyboardViewController.swift
@@ -1,5 +1,5 @@
 /**
- * Class for the Danish Scribe keybaord.
+ * Class for the Danish Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/English/ENCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/English/ENCommandVariables.swift
@@ -1,8 +1,22 @@
-//
-//  ENCommandVariables.swift
-//
-//  Variables associated with commands for the English Scribe keyboard.
-//
+/**
+ * Variables associated with commands for the English Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 func enSetConjugationLabels() {
   // Reset all form labels prior to assignment.

--- a/Keyboards/LanguageKeyboards/English/ENCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/English/ENCommandVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Variables associated with commands for the English Scribe keyboard
- *
+ * Variables associated with commands for the English Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
@@ -1,8 +1,22 @@
-//
-//  ENInterfaceVariables.swift.swift
-//
-//  Constants and functions to load the English Scribe keyboard.
-//
+/**
+ * Constants and functions to load the English Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Constants and functions to load the English Scribe keyboard
- *
+ * Constants and functions to load the English Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/English/ENKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/English/ENKeyboardViewController.swift
@@ -1,5 +1,21 @@
-//
-//  ENKeyboardViewController.swift
-//
+/**
+ * Class for the English Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 class ENKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/English/ENKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/English/ENKeyboardViewController.swift
@@ -1,6 +1,5 @@
 /**
- * Class for the English Scribe keyboard
- *
+ * Class for the English Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
@@ -1,8 +1,22 @@
-//
-//  FR-AZERTYInterfaceVariables.swift
-//
-//  Constants and functions to load the AZERTY French Scribe keyboard.
-//
+/**
+ * Constants and functions to load the AZERTY French Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Constants and functions to load the AZERTY French Scribe keyboard
- *
+ * Constants and functions to load the AZERTY French Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/French/FR-QWERTYInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FR-QWERTYInterfaceVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Constants and functions to load the QWERTY French Scribe keyboard
- *
+ * Constants and functions to load the QWERTY French Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/French/FR-QWERTYInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FR-QWERTYInterfaceVariables.swift
@@ -1,8 +1,22 @@
-//
-//  FR-QWERTYInterfaceVariables.swift
-//
-//  Constants and functions to load the QWERTY French Scribe keyboard.
-//
+/**
+ * Constants and functions to load the QWERTY French Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 public enum FrenchQWERTYKeyboardConstants {
   // iPhone keyboard layouts.

--- a/Keyboards/LanguageKeyboards/French/FRCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FRCommandVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Variables associated with commands for the French Scribe keyboard
- *
+ * Variables associated with commands for the French Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/French/FRCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FRCommandVariables.swift
@@ -1,8 +1,22 @@
-//
-//  FRCommandVariables.swift
-//
-//  Variables associated with commands for the French Scribe keyboard.
-//
+/**
+ * Variables associated with commands for the French Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 func frSetConjugationLabels() {
   // Reset all form labels prior to assignment.

--- a/Keyboards/LanguageKeyboards/French/FRKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/French/FRKeyboardViewController.swift
@@ -1,5 +1,21 @@
-//
-//  FRKeyboardViewController.swift
-//
+/**
+ * Class for the French Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 class FRKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/French/FRKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/French/FRKeyboardViewController.swift
@@ -1,6 +1,5 @@
 /**
- * Class for the French Scribe keyboard
- *
+ * Class for the French Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/German/DECommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DECommandVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Variables associated with commands for the German Scribe keyboard
- *
+ * Variables associated with commands for the German Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/German/DECommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DECommandVariables.swift
@@ -1,8 +1,22 @@
-//
-//  DECommandVariables.swift
-//
-//  Variables associated with commands for the German Scribe keyboard.
-//
+/**
+ * Variables associated with commands for the German Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 func deSetConjugationLabels() {
   // Reset all form labels prior to assignment.

--- a/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
@@ -1,8 +1,22 @@
-//
-//  DEInterfaceVariables.swift
-//
-//  Constants and functions to load the German Scribe keyboard.
-//
+/**
+ * Constants and functions to load the German Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Constants and functions to load the German Scribe keyboard
- *
+ * Constants and functions to load the German Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/German/DEKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/German/DEKeyboardViewController.swift
@@ -1,5 +1,21 @@
-//
-//  DEKeyboardViewController.swift
-//
+/**
+ * Class for the German Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 class DEKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/German/DEKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/German/DEKeyboardViewController.swift
@@ -1,6 +1,5 @@
 /**
- * Class for the German Scribe keyboard
- *
+ * Class for the German Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Hebrew/HECommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Hebrew/HECommandVariables.swift
@@ -1,8 +1,22 @@
-//
-//  HECommandVariables.swift
-//
-//  Variables associated with commands for the Hebrew Scribe keyboard.
-//
+/**
+ * Variables associated with commands for the Hebrew Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 func heSetConjugationLabels() {
   // Reset all form labels prior to assignment.

--- a/Keyboards/LanguageKeyboards/Hebrew/HECommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Hebrew/HECommandVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Variables associated with commands for the Hebrew Scribe keyboard
- *
+ * Variables associated with commands for the Hebrew Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Hebrew/HEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Hebrew/HEInterfaceVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Constants and functions to load the Hebrew Scribe keyboard
- *
+ * Constants and functions to load the Hebrew Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Hebrew/HEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Hebrew/HEInterfaceVariables.swift
@@ -1,8 +1,22 @@
-//
-//  HEInterfaceVariables.swift
-//
-//  Constants and functions to load the Hebrew Scribe keyboard.
-//
+/**
+ * Constants and functions to load the Hebrew Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/LanguageKeyboards/Hebrew/HEKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Hebrew/HEKeyboardViewController.swift
@@ -1,5 +1,21 @@
-//
-//  HEKeyboardViewController.swift
-//
+/**
+ * Class for the Hebrew Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 class HEKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/Hebrew/HEKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Hebrew/HEKeyboardViewController.swift
@@ -1,6 +1,5 @@
 /**
- * Class for the Hebrew Scribe keyboard
- *
+ * Class for the Hebrew Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Italian/ITCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITCommandVariables.swift
@@ -1,8 +1,22 @@
-//
-//  ITCommandVariables.swift
-//
-//  Variables associated with commands for the Italian Scribe keyboard.
-//
+/**
+ * Variables associated with commands for the Italian Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 func itSetConjugationLabels() {
   // Reset all form labels prior to assignment.

--- a/Keyboards/LanguageKeyboards/Italian/ITCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITCommandVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Variables associated with commands for the Italian Scribe keyboard
- *
+ * Variables associated with commands for the Italian Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Constants and functions to load the Italian Scribe keyboard
- *
+ * Constants and functions to load the Italian Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
@@ -1,8 +1,22 @@
-//
-//  ITInterfaceVariables.swift
-//
-//  Constants and functions to load the Italian Scribe keyboard.
-//
+/**
+ * Constants and functions to load the Italian Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/LanguageKeyboards/Italian/ITKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITKeyboardViewController.swift
@@ -1,6 +1,5 @@
 /**
- * Class for the Italian Scribe keyboard
- *
+ * Class for the Italian Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Italian/ITKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITKeyboardViewController.swift
@@ -1,5 +1,21 @@
-//
-//  ITKeyboardViewController.swift
-//
+/**
+ * Class for the Italian Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 class ITKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/Norwegian/NBCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Norwegian/NBCommandVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Variables associated with commands for the Norwegian Bokmål Scribe keyboard
- *
+ * Variables associated with commands for the Norwegian Bokmål Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Norwegian/NBCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Norwegian/NBCommandVariables.swift
@@ -1,8 +1,22 @@
-//
-//  NBCommandVariables.swift
-//
-//  Variables associated with commands for the Norwegian Bokmål Scribe keyboard.
-//
+/**
+ * Variables associated with commands for the Norwegian Bokmål Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 func nbSetConjugationLabels() {
   // Reset all form labels prior to assignment.

--- a/Keyboards/LanguageKeyboards/Norwegian/NBInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Norwegian/NBInterfaceVariables.swift
@@ -1,8 +1,22 @@
-//
-//  NBInterfaceVariables.swift
-//
-//  Constants and functions to load the Norwegian Bokmål Scribe keyboard.
-//
+/**
+ * Constants and functions to load the Norwegian Bokmål Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/LanguageKeyboards/Norwegian/NBInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Norwegian/NBInterfaceVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Constants and functions to load the Norwegian Bokmål Scribe keyboard
- *
+ * Constants and functions to load the Norwegian Bokmål Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Norwegian/NBKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Norwegian/NBKeyboardViewController.swift
@@ -1,5 +1,21 @@
-//
-//  NBKeyboardViewController.swift
-//
+/**
+ * Class for the Norwegian Bokmål Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 class NBKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/Norwegian/NBKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Norwegian/NBKeyboardViewController.swift
@@ -1,6 +1,5 @@
 /**
- * Class for the Norwegian Bokmål Scribe keyboard
- *
+ * Class for the Norwegian Bokmål Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Portuguese/PTCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTCommandVariables.swift
@@ -1,8 +1,22 @@
-//
-//  PTCommandVariables.swift
-//
-//  Variables associated with commands for the Portuguese Scribe keyboard.
-//
+/**
+ * Variables associated with commands for the Portuguese Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 func ptSetConjugationLabels() {
   // Reset all form labels prior to assignment.

--- a/Keyboards/LanguageKeyboards/Portuguese/PTCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTCommandVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Variables associated with commands for the Portuguese Scribe keyboard
- *
+ * Variables associated with commands for the Portuguese Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
@@ -1,8 +1,22 @@
-//
-//  PTInterfaceVariables.swift
-//
-//  Constants and functions to load the Portuguese Scribe keyboard.
-//
+/**
+ * Constants and functions to load the Portuguese Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Constants and functions to load the Portuguese Scribe keyboard
- *
+ * Constants and functions to load the Portuguese Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Portuguese/PTKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTKeyboardViewController.swift
@@ -1,5 +1,21 @@
-//
-//  PTKeyboardViewController.swift
-//
+/**
+ * Class for the Portuguese Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 class PTKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/Portuguese/PTKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTKeyboardViewController.swift
@@ -1,6 +1,5 @@
 /**
- * Class for the Portuguese Scribe keyboard
- *
+ * Class for the Portuguese Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Russian/RUCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUCommandVariables.swift
@@ -1,8 +1,22 @@
-//
-//  RUCommandVariables.swift
-//
-//  Variables associated with commands for the Russian Scribe keyboard.
-//
+/**
+ * Variables associated with commands for the Russian Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 func ruSetConjugationLabels() {
   // Reset all form labels prior to assignment.

--- a/Keyboards/LanguageKeyboards/Russian/RUCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUCommandVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Variables associated with commands for the Russian Scribe keyboard
- *
+ * Variables associated with commands for the Russian Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
@@ -1,8 +1,22 @@
-//
-//  RUInterfaceVariables.swift
-//
-//  Constants and functions to load the Russian Scribe keyboard.
-//
+/**
+ * Commands and functions to load the Russian Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Commands and functions to load the Russian Scribe keyboard
- *
+ * Commands and functions to load the Russian Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Russian/RUKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUKeyboardViewController.swift
@@ -1,6 +1,5 @@
 /**
- * Class for the Russian Scribe keyboard
- *
+ * Class for the Russian Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Russian/RUKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUKeyboardViewController.swift
@@ -1,5 +1,21 @@
-//
-//  RUKeyboardViewController.swift
-//
+/**
+ * Class for the Russian Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 class RUKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/Spanish/ESCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESCommandVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Variables associated with commands for the Spanish Scribe keyboard
- *
+ * Variables associated with commands for the Spanish Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Spanish/ESCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESCommandVariables.swift
@@ -1,8 +1,22 @@
-//
-//  ESCommandVariables.swift
-//
-//  Variables associated with commands for the Spanish Scribe keyboard.
-//
+/**
+ * Variables associated with commands for the Spanish Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 func esSetConjugationLabels() {
   // Reset all form labels prior to assignment.

--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -1,8 +1,22 @@
-//
-//  ESInterfaceVariables.swift
-//
-//  Constants and functions to load the Spanish Scribe keyboard.
-//
+/**
+ * Constants and functions to load the Spanish Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Constants and functions to load the Spanish Scribe keyboard
- *
+ * Constants and functions to load the Spanish Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Spanish/ESKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESKeyboardViewController.swift
@@ -1,6 +1,5 @@
 /**
- * Class for the Spanish Scribe keyboard
- *
+ * Class for the Spanish Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Spanish/ESKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESKeyboardViewController.swift
@@ -1,5 +1,21 @@
-//
-//  ESKeyboardViewController.swift
-//
+/**
+ * Class for the Spanish Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 class ESKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/Swedish/SVCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVCommandVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Variables associated with commands for the Swedish Scribe keyboard
- *
+ * Variables associated with commands for the Swedish Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Swedish/SVCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVCommandVariables.swift
@@ -1,8 +1,22 @@
-//
-//  SVCommandVariables.swift
-//
-//  Variables associated with commands for the Swedish Scribe keyboard.
-//
+/**
+ * Variables associated with commands for the Swedish Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 func svSetConjugationLabels() {
   // Reset all form labels prior to assignment.

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -1,6 +1,5 @@
 /**
- * Constants and functions to load the Swedish Scribe keyboard
- *
+ * Constants and functions to load the Swedish Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -1,6 +1,22 @@
-//
-//  SVInterfaceVariables.swift
-//
+/**
+ * Constants and functions to load the Swedish Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 //  Constants and functions to load the Swedish Scribe keyboard.
 //
 

--- a/Keyboards/LanguageKeyboards/Swedish/SVKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVKeyboardViewController.swift
@@ -1,6 +1,5 @@
 /**
- * Class for the Swedish Scribe keyboard
- *
+ * Class for the Swedish Scribe keyboard.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Keyboards/LanguageKeyboards/Swedish/SVKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVKeyboardViewController.swift
@@ -1,5 +1,21 @@
-//
-//  SVKeyboardViewController.swift
-//
+/**
+ * Class for the Swedish Scribe keyboard
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 class SVKeyboardViewController: KeyboardViewController {}

--- a/Scribe/AboutTab/AboutTableData.swift
+++ b/Scribe/AboutTab/AboutTableData.swift
@@ -1,19 +1,22 @@
-//
-//  Copyright (C) 2023 Scribe
-//
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-//
-//  You should have received a copy of the GNU General Public License
-//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-//
+/**
+ * Controls data displayed in the About tab
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import Foundation
 

--- a/Scribe/AboutTab/AboutTableData.swift
+++ b/Scribe/AboutTab/AboutTableData.swift
@@ -1,6 +1,5 @@
 /**
- * Controls data displayed in the About tab
- *
+ * Controls data displayed in the About tab.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/AboutTab/AboutViewController.swift
+++ b/Scribe/AboutTab/AboutViewController.swift
@@ -1,6 +1,5 @@
 /**
- * Functions for the About tab
- *
+ * Functions for the About tab.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/AboutTab/AboutViewController.swift
+++ b/Scribe/AboutTab/AboutViewController.swift
@@ -1,19 +1,22 @@
-//
-//  Copyright (C) 2023 Scribe
-//
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-//
-//  You should have received a copy of the GNU General Public License
-//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-//
+/**
+ * Functions for the About tab
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 import MessageUI

--- a/Scribe/AboutTab/InformationScreenVC.swift
+++ b/Scribe/AboutTab/InformationScreenVC.swift
@@ -1,6 +1,22 @@
-//
-//  InformationScreenVC.swift
-//
+/**
+ * Sets up information views in the About tab
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Scribe/AboutTab/InformationScreenVC.swift
+++ b/Scribe/AboutTab/InformationScreenVC.swift
@@ -1,6 +1,5 @@
 /**
- * Sets up information views in the About tab
- *
+ * Sets up information views in the About tab.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/AppDelegate.swift
+++ b/Scribe/AppDelegate.swift
@@ -1,8 +1,22 @@
-//
-//  AppDelegate.swift
-//
-//  A class of methods to manage Scribe's behaviors.
-//
+/**
+ * Class of methods to manage Scribe's behaviors
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import CoreData
 import UIKit

--- a/Scribe/AppDelegate.swift
+++ b/Scribe/AppDelegate.swift
@@ -1,6 +1,5 @@
 /**
- * Class of methods to manage Scribe's behaviors
- *
+ * Class of methods to manage Scribe's behaviors.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/AppExtensions.swift
+++ b/Scribe/AppExtensions.swift
@@ -1,6 +1,22 @@
-//
-//  AppExtensions.swift
-//
+/**
+ * Extensions for the Scribe app
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Scribe/AppExtensions.swift
+++ b/Scribe/AppExtensions.swift
@@ -1,6 +1,5 @@
 /**
- * Extensions for the Scribe app
- *
+ * Extensions for the Scribe app.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/AppStyling.swift
+++ b/Scribe/AppStyling.swift
@@ -1,8 +1,22 @@
-//
-//  AppStyling.swift
-//
-//  Functions to style app elements.
-//
+/**
+ * Functions to style app elements
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Scribe/AppStyling.swift
+++ b/Scribe/AppStyling.swift
@@ -1,6 +1,5 @@
 /**
- * Functions to style app elements
- *
+ * Functions to style app elements.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/AppTexts/AppTextStyling.swift
+++ b/Scribe/AppTexts/AppTextStyling.swift
@@ -1,6 +1,5 @@
 /**
- * Functions returning styled text elements for the app screen
- *
+ * Functions returning styled text elements for the app screen.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/AppTexts/AppTextStyling.swift
+++ b/Scribe/AppTexts/AppTextStyling.swift
@@ -1,8 +1,22 @@
-//
-//  AppTextIcons.swift
-//
-//  Functions returning styled text elements for the app screen.
-//
+/**
+ * Functions returning styled text elements for the app screen
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Scribe/AppTexts/English/ENAppText.swift
+++ b/Scribe/AppTexts/English/ENAppText.swift
@@ -1,6 +1,5 @@
 /**
- * The English app text for the Scribe app
- *
+ * The English app text for the Scribe app.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/AppTexts/English/ENAppText.swift
+++ b/Scribe/AppTexts/English/ENAppText.swift
@@ -1,6 +1,22 @@
-//
-//  ENAppText.swift
-//
+/**
+ * The English app text for the Scribe app
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 //  The English app text for the Scribe app.
 //
 

--- a/Scribe/AppTexts/English/ENPrivacyPolicy.swift
+++ b/Scribe/AppTexts/English/ENPrivacyPolicy.swift
@@ -1,8 +1,7 @@
 /**
- * The English privacy policy for the Scribe app
+ * The English privacy policy for the Scribe app.
  *
- * `PRIVACY.txt` is formatted for GitHub, this is formatted for modular sizing
- *
+ *`PRIVACY.txt` is formatted for GitHub, this is formatted for modular sizing.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/AppTexts/English/ENPrivacyPolicy.swift
+++ b/Scribe/AppTexts/English/ENPrivacyPolicy.swift
@@ -1,10 +1,24 @@
-//
-//  PrivacyPolicy.swift
-//
-//  The English privacy policy for the Scribe app.
-//
-//  PRIVACY.txt is formatted for GitHub, and this is formatted for modular sizing.
-//
+/**
+ * The English privacy policy for the Scribe app
+ *
+ * `PRIVACY.txt` is formatted for GitHub, this is formatted for modular sizing
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 let enPrivacyPolicyTitle = "Privacy Policy"
 let enPrivacyPolicyPageCaption = "Keeping you safe"

--- a/Scribe/AppTexts/English/ENThirdPartyLicenses.swift
+++ b/Scribe/AppTexts/English/ENThirdPartyLicenses.swift
@@ -1,6 +1,5 @@
 /**
- * Text displayed on the English Third Party Licenses view
- *
+ * Text displayed on the English Third Party Licenses view.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/AppTexts/English/ENThirdPartyLicenses.swift
+++ b/Scribe/AppTexts/English/ENThirdPartyLicenses.swift
@@ -1,6 +1,22 @@
-//
-//  ENThirdPartyLicenses.swift
-//
+/**
+ * Text displayed on the English Third Party Licenses view
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 let enThirdPartyLicensesTitle = "Third-party licenses"
 let enThirdPartyLicensesCaption = "Whose code we used"

--- a/Scribe/AppTexts/English/ENWikimediaAndScribe.swift
+++ b/Scribe/AppTexts/English/ENWikimediaAndScribe.swift
@@ -1,6 +1,22 @@
-//
-//  ENWikimediaAndScribe.swift
-//
+/**
+ * Text displayed on the English Wikimedia and Scribe view
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 let enWikimediaAndScribeTitle = "Wikimedia and Scribe"
 let enWikimediaAndScribeCaption = "How we work together"

--- a/Scribe/AppTexts/English/ENWikimediaAndScribe.swift
+++ b/Scribe/AppTexts/English/ENWikimediaAndScribe.swift
@@ -1,6 +1,5 @@
 /**
- * Text displayed on the English Wikimedia and Scribe view
- *
+ * Text displayed on the English Wikimedia and Scribe view.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/AppTexts/German/DEAppText.swift
+++ b/Scribe/AppTexts/German/DEAppText.swift
@@ -1,6 +1,5 @@
 /**
- * The German app text for the Scribe app
- *
+ * The German app text for the Scribe app.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/AppTexts/German/DEAppText.swift
+++ b/Scribe/AppTexts/German/DEAppText.swift
@@ -1,8 +1,22 @@
-//
-//  DEAppText.swift
-//
-//  The German app text for the Scribe app.
-//
+/**
+ * The German app text for the Scribe app
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Scribe/AppTexts/German/DEPrivacyPolicy.swift
+++ b/Scribe/AppTexts/German/DEPrivacyPolicy.swift
@@ -1,10 +1,24 @@
-//
-//  PrivacyPolicy.swift
-//
-//  The German privacy policy for the Scribe app.
-//
-//  PRIVACY.txt is formatted for GitHub, and this is formatted for modular sizing.
-//
+/**
+ * The German privacy policy for the Scribe app
+ *
+ * `PRIVACY.txt` is formatted for GitHub, this is formatted for modular sizing
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 let dePrivacyPolicyTitle = "Datenschutzrichtlinie"
 let dePrivacyPolicyPageCaption = "Wir sorgen für Ihre Sicherheit"

--- a/Scribe/AppTexts/German/DEPrivacyPolicy.swift
+++ b/Scribe/AppTexts/German/DEPrivacyPolicy.swift
@@ -1,8 +1,7 @@
 /**
- * The German privacy policy for the Scribe app
+ * The German privacy policy for the Scribe app.
  *
- * `PRIVACY.txt` is formatted for GitHub, this is formatted for modular sizing
- *
+ *`PRIVACY.txt` is formatted for GitHub, this is formatted for modular sizing.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/AppUISymbols.swift
+++ b/Scribe/AppUISymbols.swift
@@ -1,6 +1,5 @@
 /**
- * Functions returning symbols for the app UI
- *
+ * Functions returning symbols for the app UI.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/AppUISymbols.swift
+++ b/Scribe/AppUISymbols.swift
@@ -1,8 +1,22 @@
-//
-//  AppUISymbols.swift
-//
-//  Functions returning symbols for the app UI.
-//
+/**
+ * Functions returning symbols for the app UI
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
+++ b/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
@@ -1,6 +1,22 @@
-//
-//  InfoChildTableViewCell.swift
-//
+/**
+ * Class for a setting component with a heading, description and switch
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
+++ b/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
@@ -1,6 +1,5 @@
 /**
- * Class for a setting component with a heading, description and switch
- *
+ * Class for a setting component with a heading, description and switch.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/Components/TableViewTemplateViewController.swift
+++ b/Scribe/Components/TableViewTemplateViewController.swift
@@ -1,6 +1,22 @@
-//
-//  TableViewTemplateViewController.swift
-//
+/**
+ * Controls the table views within the app
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Scribe/Components/TableViewTemplateViewController.swift
+++ b/Scribe/Components/TableViewTemplateViewController.swift
@@ -1,6 +1,5 @@
 /**
- * Controls the table views within the app
- *
+ * Controls the table views within the app.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/Components/UITableViewCells/AboutTableViewCell.swift
+++ b/Scribe/Components/UITableViewCells/AboutTableViewCell.swift
@@ -1,19 +1,22 @@
-//
-//  Copyright (C) 2023 Scribe
-//
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-//
-//  You should have received a copy of the GNU General Public License
-//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-//
+/**
+ * Class for a button component with a label, icon and link icon
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Scribe/Components/UITableViewCells/AboutTableViewCell.swift
+++ b/Scribe/Components/UITableViewCells/AboutTableViewCell.swift
@@ -1,6 +1,5 @@
 /**
- * Class for a button component with a label, icon and link icon
- *
+ * Class for a button component with a label, icon and link icon.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/Extensions/UIEdgeInsetsExtensions.swift
+++ b/Scribe/Extensions/UIEdgeInsetsExtensions.swift
@@ -1,6 +1,5 @@
 /**
- * Extensions for UIEdgeInsets
- *
+ * Extensions for UIEdgeInsets.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/Extensions/UIEdgeInsetsExtensions.swift
+++ b/Scribe/Extensions/UIEdgeInsetsExtensions.swift
@@ -1,19 +1,22 @@
-//
-//  Copyright (C) 2023 Scribe
-//
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-//
-//  You should have received a copy of the GNU General Public License
-//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-//
+/**
+ * Extensions for UIEdgeInsets
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Scribe/InstallationTab/InstallationVC.swift
+++ b/Scribe/InstallationTab/InstallationVC.swift
@@ -1,8 +1,22 @@
-//
-//  ViewController.swift
-//
-//  The ViewController for the Installation screen of the Scribe app.
-//
+/**
+ * The ViewController for the Installation screen of the Scribe app
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Scribe/InstallationTab/InstallationVC.swift
+++ b/Scribe/InstallationTab/InstallationVC.swift
@@ -1,6 +1,5 @@
 /**
- * The ViewController for the Installation screen of the Scribe app
- *
+ * The ViewController for the Installation screen of the Scribe app.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/ParentTableCellModel.swift
+++ b/Scribe/ParentTableCellModel.swift
@@ -1,6 +1,5 @@
 /**
- * Contains structs that control how buttons in the About tab are built
- *
+ * Contains structs that control how buttons in the About tab are built.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/ParentTableCellModel.swift
+++ b/Scribe/ParentTableCellModel.swift
@@ -1,19 +1,22 @@
-//
-//  Copyright (C) 2023 Scribe
-//
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-//
-//  You should have received a copy of the GNU General Public License
-//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-//
+/**
+ * Contains structs that control how buttons in the About tab are built
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import Foundation
 

--- a/Scribe/SettingsTab/SettingsTableData.swift
+++ b/Scribe/SettingsTab/SettingsTableData.swift
@@ -1,6 +1,22 @@
-//
-//  SettingsTableData.swift
-//
+/**
+ * Controls data displayed in the Settings tab
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import Foundation
 

--- a/Scribe/SettingsTab/SettingsTableData.swift
+++ b/Scribe/SettingsTab/SettingsTableData.swift
@@ -1,6 +1,5 @@
 /**
- * Controls data displayed in the Settings tab
- *
+ * Controls data displayed in the Settings tab.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/SettingsTab/SettingsViewController.swift
+++ b/Scribe/SettingsTab/SettingsViewController.swift
@@ -1,19 +1,22 @@
-//
-//  Copyright (C) 2023 Scribe
-//
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-//
-//  You should have received a copy of the GNU General Public License
-//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-//
+/**
+ * Functions for the Settings tab
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Scribe/SettingsTab/SettingsViewController.swift
+++ b/Scribe/SettingsTab/SettingsViewController.swift
@@ -1,6 +1,5 @@
 /**
- * Functions for the Settings tab
- *
+ * Functions for the Settings tab.
  *
  * Copyright (C) 2023 Scribe
  *

--- a/Scribe/Views/BaseTableViewController.swift
+++ b/Scribe/Views/BaseTableViewController.swift
@@ -1,19 +1,22 @@
-//
-//  Copyright (C) 2023 Scribe
-//
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-//
-//  You should have received a copy of the GNU General Public License
-//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-//
+/**
+ * Base for table view in the Scribe app
+ *
+ *
+ * Copyright (C) 2023 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 import UIKit
 

--- a/Scribe/Views/BaseTableViewController.swift
+++ b/Scribe/Views/BaseTableViewController.swift
@@ -1,6 +1,5 @@
 /**
- * Base for table view in the Scribe app
- *
+ * Base for table view in the Scribe app.
  *
  * Copyright (C) 2023 Scribe
  *


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

Added a generic copyright notice to all .swift files in the directory, with a short description for each file. For those that already had a description, I just copied the existing one; for others, I came up with one to the best of my abilities.

### Related issue

- #391 
