### PR TITLE
fix noun-gender annotation formatting on device orientation change #396

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 ### 🐞 Bug Fixes
 
 - The transition from between portrait and landscape mode was dramatically improved ([#25](https://github.com/scribe-org/Scribe-iOS/issues/33)).
-<!-- - Bugs were fixed that were causing the autocompletions to trigger to regularly. -->
+- Annotations under autosuggestions and autocompletions are no longer distorted during an orientation transition ([#396](https://github.com/scribe-org/Scribe-iOS/issues/396)).
+<!-- - Bugs were fixed that were causing the autocompletions to trigger too regularly. -->
 
 ### ♻️ Code Refactoring
 

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -206,7 +206,7 @@ class KeyboardViewController: UIInputViewController {
   /// - A call to loadKeys to reload the display after an orientation change
   override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
-    coordinator.animate(alongsideTransition: { (context) in
+    coordinator.animate(alongsideTransition: { _ in
       self.updateViewConstraints()
       self.loadKeys()
     })

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -206,9 +206,10 @@ class KeyboardViewController: UIInputViewController {
   /// - A call to loadKeys to reload the display after an orientation change
   override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
-    Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false) { _ in
+    coordinator.animate(alongsideTransition: { (context) in
       self.updateViewConstraints()
-    }
+      self.loadKeys()
+    })
     Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false) { _ in
       isFirstKeyboardLoad = true
       self.loadKeys()
@@ -226,9 +227,11 @@ class KeyboardViewController: UIInputViewController {
       alternatesShapeLayer.removeFromSuperlayer()
     }
     annotationState = false
-    isFirstKeyboardLoad = true
-    loadKeys()
-    isFirstKeyboardLoad = false
+    Timer.scheduledTimer(withTimeInterval: 0.1, repeats: false) { _ in
+      isFirstKeyboardLoad = true
+      self.loadKeys()
+      isFirstKeyboardLoad = false
+    }
   }
 
   // MARK: Scribe Command Elements


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

### Description

The pull request provides a solution for issue 396: noun-gender annotation formatting broken on device orientation change. In the app, annotation size and position is calculated depending on the frame of the assigned keys. I think the error occurs when auto layout changes the frames. To fix the bug, I called loadKeys() again when auto layout is finished.

The fix is tested on 
- iPhone 12, iOS 17.3.1. (physical device)
- iPhone 15, iOS 17.0. (simulator)
- iPhone 15 Pro, iOS 17.0. (simulator)
- iPad (10th generation), iOS 17.0 (simulator)
- iPhone SE (3rd generation), iOS 17.0 (simulator)

### Related issue

- #396 
