### PR TITLE
File Template with Copyright Header

### DIFF
--- a/ScribeTemplates/ScribeHeader.xctemplate/TemplateInfo.plist
+++ b/ScribeTemplates/ScribeHeader.xctemplate/TemplateInfo.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Identifier</key>
+    <string>com.example.templates.mytemplate</string>
+    <key>Kind</key>
+    <string>Xcode.IDEKit.TextSubstitutionFileTemplateKind</string>
+    <key>Ancestors</key>
+    <array>
+        <string>com.apple.dt.unit-test-class</string>
+    </array>
+</dict>
+</plist>
+

--- a/ScribeTemplates/ScribeHeader.xctemplate/___FILEBASENAME___.swift
+++ b/ScribeTemplates/ScribeHeader.xctemplate/___FILEBASENAME___.swift
@@ -1,0 +1,18 @@
+/** 
+  * [Describe what you want to do with your file here]
+  *
+  * Copyright (C) 2023 Scribe
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  */


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This adds a template to a new directory called `ScribeTemplates`, which adds the copyright notice used in #403 to any newly created file using said template. You would find it when creating a new file in Xcode, where you would scroll to the bottom and select the template in a new category called "ScribeTemplates".
To use this template, you would first have to add it to your own Xcode templates by:
1. Creating a "Templates" directory in your Xcode folder (found at `Users/[your username]/Library/Developer/Xcode`)
2. Symlink the Scribe template into "Templates"

Using commands:
```
mkdir ~/Library/Developer/Xcode/Templates
ln -s [Path to your Scribe directory]/Scribe-iOS/ScribeTemplates ~/Library/Developer/Xcode/Templates/
```

### Related issue

- #405 
