### PR TITLE
Allow for swiping between conjugation and declension views #361

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 - German indefinite pronouns are now selectable from the case-declension display ([#303](https://github.com/scribe-org/Scribe-iOS/issues/303)).
 - German imperfect verb conjugations now insert both the auxiliary verb and the past participle with the cursor between them.
 - Tab and caps lock keys and their functionalities have been added to expanded iPad layouts ([#371](https://github.com/scribe-org/Scribe-iOS/issues/371)).
+- Users can now swipe between the conjugation and declension views ([#361](https://github.com/scribe-org/Scribe-iOS/issues/361)).
 
 ### 🎨 Design Changes
 

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -1207,13 +1207,13 @@ class KeyboardViewController: UIInputViewController {
 
   /// Sets up all buttons and labels for the conjugation view given constraints to determine the dimensions.
   func setConjugationBtns() {
-    // add swipe functionality to the conjugation and declension views
+    // Add swipe functionality to the conjugation and declension views.
     let swipeRight = UISwipeGestureRecognizer(target: self, action: #selector(shiftLeft))
     keyboardView.addGestureRecognizer(swipeRight)
     let swipeLeft = UISwipeGestureRecognizer(target: self, action: #selector(shiftRight))
     swipeLeft.direction = .left
     keyboardView.addGestureRecognizer(swipeLeft)
-    
+
     // Set the conjugation view to 2x2 for Swedish and Russian past tense.
     if controllerLanguage == "Swedish" {
       formsDisplayDimensions = .view2x2
@@ -1579,7 +1579,7 @@ class KeyboardViewController: UIInputViewController {
       typedWordAnnotation(KVC: self)
     }
   }
-  
+
   @objc func shiftLeft() {
     if commandState == .displayInformation {
       tipView?.updatePrevious()
@@ -1588,7 +1588,7 @@ class KeyboardViewController: UIInputViewController {
       loadKeys()
     }
   }
- 
+
   @objc func shiftRight() {
     if commandState == .displayInformation {
       tipView?.updateNext()

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -1207,6 +1207,13 @@ class KeyboardViewController: UIInputViewController {
 
   /// Sets up all buttons and labels for the conjugation view given constraints to determine the dimensions.
   func setConjugationBtns() {
+    // add swipe functionality to the conjugation and declension views
+    let swipeRight = UISwipeGestureRecognizer(target: self, action: #selector(shiftLeft))
+    keyboardView.addGestureRecognizer(swipeRight)
+    let swipeLeft = UISwipeGestureRecognizer(target: self, action: #selector(shiftRight))
+    swipeLeft.direction = .left
+    keyboardView.addGestureRecognizer(swipeLeft)
+    
     // Set the conjugation view to 2x2 for Swedish and Russian past tense.
     if controllerLanguage == "Swedish" {
       formsDisplayDimensions = .view2x2
@@ -1570,6 +1577,24 @@ class KeyboardViewController: UIInputViewController {
   func conditionallyDisplayAnnotation() {
     if [.idle, .alreadyPlural, .invalid].contains(commandState) {
       typedWordAnnotation(KVC: self)
+    }
+  }
+  
+  @objc func shiftLeft() {
+    if commandState == .displayInformation {
+      tipView?.updatePrevious()
+    } else {
+      conjugationStateLeft()
+      loadKeys()
+    }
+  }
+ 
+  @objc func shiftRight() {
+    if commandState == .displayInformation {
+      tipView?.updateNext()
+    } else {
+      conjugationStateRight()
+      loadKeys()
     }
   }
 
@@ -2256,20 +2281,10 @@ class KeyboardViewController: UIInputViewController {
       commandBar.attributedText = pluralPromptAndColorPlaceholder
 
     case "shiftFormsDisplayLeft":
-      if commandState == .displayInformation {
-        tipView?.updatePrevious()
-      } else {
-        conjugationStateLeft()
-        loadKeys()
-      }
+      shiftLeft()
 
     case "shiftFormsDisplayRight":
-      if commandState == .displayInformation {
-        tipView?.updateNext()
-      } else {
-        conjugationStateRight()
-        loadKeys()
-      }
+      shiftRight()
 
     case "firstPersonSingular":
       returnConjugation(keyPressed: sender, requestedForm: formFPS)


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

The pull request provided by henrikth93 and Taufi offers a solution for issue #361: enabling swiping between conjugation and declension views. Alongside the existing left and right buttons used for view switching, users can now also swipe to navigate between views.

The fix is tested by henrikth93 and Taufi on

iPhone 12, iOS 17.3.1. (physical device)
iPhone 15, iOS 17.4. (simulator)
iPhone 15 Pro, iOS 17.0. (simulator)
iPad (10th generation), iOS 17.0 (simulator)
iPhone SE (3rd generation), iOS 17.0 (simulator)

Please note: Swipe gestures do not work with all simulators. It probably depends on whether XCode is running under Rosetta or not (https://forums.developer.apple.com/forums/thread/696832)

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #361
