### PR TITLE
Added explanation for conjugations missing from Wikidata (#400)

### DIFF
--- a/Keyboards/KeyboardsBase/KeyboardStyling.swift
+++ b/Keyboards/KeyboardsBase/KeyboardStyling.swift
@@ -30,19 +30,25 @@ func styleBtn(btn: UIButton, title: String, radius: CGFloat) {
   btn.layer.masksToBounds = false
   btn.layer.cornerRadius = radius
   btn.setTitle(title, for: .normal)
-  // Displays info button for missing data
-  if title == invalidCommandMsg {
-    if #available(iOS 15.0, *) {
-      var configuration = UIButton.Configuration.plain()
-      configuration.baseForegroundColor = UITraitCollection.current.userInterfaceStyle == .light ? specialKeyColor : keyColor
-      configuration.image = UIImage(systemName: "info.circle.fill")
-      configuration.imagePlacement = .trailing
-      configuration.imagePadding = 3
-      btn.configuration = configuration
+  if #available(iOS 15.0, *) {
+    // Displays info button for missing data
+    if title == invalidCommandMsg {
+      btn.configuration = UIButton.Configuration.plain()
+      btn.configuration?.baseForegroundColor = UITraitCollection.current.userInterfaceStyle == .light ? specialKeyColor : keyColor
+      btn.configuration?.image = UIImage(systemName: "info.circle.fill")
+      btn.configuration?.imagePlacement = .trailing
+      btn.configuration?.imagePadding = 3
     } else {
+      btn.configuration = nil
+    }
+  } else {
+    if title == invalidCommandMsg {
       btn.semanticContentAttribute = .forceLeftToRight // Has to be changed once support for RTL languages is implemented
       btn.setImage(UIImage(systemName: "info.circle.fill"), for: .normal)
       btn.tintColor = UITraitCollection.current.userInterfaceStyle == .light ? specialKeyColor : keyColor
+    } else {
+      btn.semanticContentAttribute = .unspecified
+      btn.setImage(nil, for: .normal)
     }
   }
   btn.contentHorizontalAlignment = UIControl.ContentHorizontalAlignment.center

--- a/Keyboards/KeyboardsBase/KeyboardStyling.swift
+++ b/Keyboards/KeyboardsBase/KeyboardStyling.swift
@@ -30,6 +30,21 @@ func styleBtn(btn: UIButton, title: String, radius: CGFloat) {
   btn.layer.masksToBounds = false
   btn.layer.cornerRadius = radius
   btn.setTitle(title, for: .normal)
+  // Displays info button for missing data
+  if title == invalidCommandMsg {
+    if #available(iOS 15.0, *) {
+      var configuration = UIButton.Configuration.plain()
+      configuration.baseForegroundColor = UITraitCollection.current.userInterfaceStyle == .light ? specialKeyColor : keyColor
+      configuration.image = UIImage(systemName: "info.circle.fill")
+      configuration.imagePlacement = .trailing
+      configuration.imagePadding = 3
+      btn.configuration = configuration
+    } else {
+      btn.semanticContentAttribute = .forceLeftToRight // Has to be changed once support for RTL languages is implemented
+      btn.setImage(UIImage(systemName: "info.circle.fill"), for: .normal)
+      btn.tintColor = UITraitCollection.current.userInterfaceStyle == .light ? specialKeyColor : keyColor
+    }
+  }
   btn.contentHorizontalAlignment = UIControl.ContentHorizontalAlignment.center
   btn.setTitleColor(keyCharColor, for: .normal)
 

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -313,13 +313,13 @@ class KeyboardViewController: UIInputViewController {
     formKeySingle.addSubview(tipView)
     formKeySingle.isUserInteractionEnabled = false
     tipView.leadingAnchor.constraint(
-      equalTo: formKeySingle.leadingAnchor, constant: DeviceType.isPhone ? 15 : 40
+      equalTo: formKeySingle.leadingAnchor
     ).isActive = true
     tipView.trailingAnchor.constraint(
-      equalTo: formKeySingle.trailingAnchor, constant: DeviceType.isPhone ? -15 : -40
+      equalTo: formKeySingle.trailingAnchor
     ).isActive = true
-    tipView.topAnchor.constraint(equalTo: formKeySingle.topAnchor, constant: 8).isActive = true
-    tipView.bottomAnchor.constraint(equalTo: formKeySingle.bottomAnchor, constant: -5).isActive = true
+    tipView.topAnchor.constraint(equalTo: formKeySingle.topAnchor).isActive = true
+    tipView.bottomAnchor.constraint(equalTo: formKeySingle.bottomAnchor).isActive = true
     styleBtn(btn: formKeySingle, title: "", radius: keyCornerRadius)
   }
 
@@ -1381,11 +1381,13 @@ class KeyboardViewController: UIInputViewController {
   }
 
   /// Deactivates all buttons that are associated with the conjugation display.
-  func deactivateConjugationDisplay() {
-    deactivateBtn(btn: shiftFormsDisplayLeft)
-    shiftFormsDisplayLeft.tintColor = UIColor.clear
-    deactivateBtn(btn: shiftFormsDisplayRight)
-    shiftFormsDisplayRight.tintColor = UIColor.clear
+  func deactivateConjugationDisplay(deactivateShiftForms: Bool) {
+    if (deactivateShiftForms) {
+      deactivateBtn(btn: shiftFormsDisplayLeft)
+      shiftFormsDisplayLeft.tintColor = UIColor.clear
+      deactivateBtn(btn: shiftFormsDisplayRight)
+      shiftFormsDisplayRight.tintColor = UIColor.clear
+    }
 
     let allFormDisplayButtons: [UIButton] =
       get3x2FormDisplayButtons()
@@ -2012,7 +2014,7 @@ class KeyboardViewController: UIInputViewController {
       scribeKey.setTitle("", for: .normal)
       commandBar.set() // set here so text spacing is appropriate
       conditionallyShowAutoActionPartitions()
-      deactivateConjugationDisplay()
+      deactivateConjugationDisplay(deactivateShiftForms: true)
 
       if DeviceType.isPhone {
         translateKey.titleLabel?.font = .systemFont(ofSize: scribeKey.frame.height * scalarCommandKeyHeightPhone)
@@ -2117,6 +2119,7 @@ class KeyboardViewController: UIInputViewController {
       if commandState == .selectVerbConjugation {
         setVerbConjugationState()
       } else if commandState == .displayInformation {
+        deactivateConjugationDisplay(deactivateShiftForms: false) // Ensures that previously displayed buttons disappear before showing the info view
         setInformationState()
       } else {
         setCaseDeclensionState()

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -305,6 +305,7 @@ class KeyboardViewController: UIInputViewController {
 
   /// Sets the tooltip to display information to the user.
   func setInformationState() {
+    setFormDisplay1x1View()
     let contentData = InformationToolTipData.getContent()
     let datasources = contentData.enumerated().compactMap { _, text in
       createInformationStateDatasource(text: text, backgroundColor: keyColor)

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -1388,7 +1388,7 @@ class KeyboardViewController: UIInputViewController {
 
   /// Deactivates all buttons that are associated with the conjugation display.
   func deactivateConjugationDisplay(deactivateShiftForms: Bool) {
-    if (deactivateShiftForms) {
+    if deactivateShiftForms {
       deactivateBtn(btn: shiftFormsDisplayLeft)
       shiftFormsDisplayLeft.tintColor = UIColor.clear
       deactivateBtn(btn: shiftFormsDisplayRight)

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -130,6 +130,11 @@ class KeyboardViewController: UIInputViewController {
   ///   - btn: the button to be deactivated.
   func deactivateBtn(btn: UIButton) {
     btn.setTitle("", for: .normal)
+    if #available(iOS 15.0, *) {
+      btn.configuration?.image = nil
+    } else {
+      btn.setImage(nil, for: .normal)
+    }
     btn.backgroundColor = UIColor.clear
     btn.removeTarget(self, action: #selector(executeKeyActions), for: .touchUpInside)
     btn.removeTarget(self, action: #selector(keyTouchDown), for: .touchDown)

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
@@ -232,7 +232,7 @@ func returnConjugation(keyPressed: UIButton, requestedForm: String) {
 
   let wordPressed = keyPressed.titleLabel?.text ?? ""
   var displayInfo = false
-  
+
   // Select to change into a ToolTipView if the user selects a conjugation that is unavailable
   if wordPressed == invalidCommandMsg {
     displayInfo = true

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
@@ -231,10 +231,11 @@ func returnConjugation(keyPressed: UIButton, requestedForm: String) {
   }
 
   let wordPressed = keyPressed.titleLabel?.text ?? ""
-
-  // Don't change proxy if they select a conjugation that's missing.
+  var displayInfo = false
+  
+  // Select to change into a ToolTipView if the user selects a conjugation that is unavailable
   if wordPressed == invalidCommandMsg {
-    proxy.insertText("")
+    displayInfo = true
   } else if formsDisplayDimensions == .view3x2 {
     wordToReturn = LanguageDBManager.shared.queryVerb(of: verbToConjugate, with: outputCols)[0]
     potentialWordsToReturn = wordToReturn.components(separatedBy: " ")
@@ -266,9 +267,13 @@ func returnConjugation(keyPressed: UIButton, requestedForm: String) {
     }
   }
 
-  autoActionState = .suggest
-  commandState = .idle
-  conjViewShiftButtonsState = .bothInactive
+  if displayInfo {
+    commandState = .displayInformation
+  } else {
+    autoActionState = .suggest
+    commandState = .idle
+    conjViewShiftButtonsState = .bothInactive
+  }
 }
 
 /// Returns the conjugation state to its initial conjugation based on the keyboard language.

--- a/Keyboards/KeyboardsBase/ToolTip/ToolTipView.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/ToolTipView.swift
@@ -1,5 +1,5 @@
 /**
- * The main file used to control tooltips.
+ * Shows the user an information view.
  *
  * Copyright (C) 2023 Scribe
  *


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

When a word is present in Wikidata, but doesn't have any data for conjugation, the buttons in the conjugation screen show "Not in Wikidata" in the specific keyboard's language instead.
Here I added a little info symbol to these buttons. Clicking them now leads the user to an info view describing how Scribe data is fetched from Wikidata, the same one used when entering a word missing from the database.

#### Example:
<img width="345" alt="image" src="https://github.com/scribe-org/Scribe-iOS/assets/63468878/20549ca6-5b8f-4d9c-8e20-50e193be3dd2">
<img width="348" alt="image" src="https://github.com/scribe-org/Scribe-iOS/assets/63468878/6b148682-5965-4bde-a75b-07408be0e161">

### Related issue

- #400 
