### PR TITLE
#292 Load UI lexicon

### DIFF
--- a/Scribe/ParentTableCellModel.swift
+++ b/Scribe/ParentTableCellModel.swift
@@ -38,8 +38,8 @@ struct Section {
   init(
     sectionTitle: String,
     imageString: String? = nil,
-    hasToggle: Bool = false, h _: Bool = false,
-
+    hasToggle: Bool = false, 
+    hasNestedNavigation: Bool = false,
     sectionState: SectionState,
     shortDescription: String? = nil,
     externalLink: Bool? = false
@@ -47,7 +47,7 @@ struct Section {
     self.sectionTitle = sectionTitle
     self.imageString = imageString
     self.hasToggle = hasToggle
-    hasNestedNavigation = hasNestedNavigation
+    self.hasNestedNavigation = hasNestedNavigation
     self.sectionState = sectionState
     self.shortDescription = shortDescription
     self.externalLink = externalLink


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

The UILexicon is unable to load due to the Language Database being located in the app's main bundle, where writing data is not permitted. The solution involves copying the database into the application support directory and accessing it from there.

Additionally, the pull request includes a minor fix for an issue in ParentTableCellModel.

The fix is tested on

- iPhone 12, iOS 17.3.1. (physical device)
- iPhone 15, iOS 17.0. (simulator)
- iPad (10th generation), iOS 17.0 (simulator)
- iPhone SE (3rd generation), iOS 17.0 (simulator)

The simulator tests are essentially retests because the error doesn't manifest there.

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #292
