### PR TITLE
Removed swiftLint warning closure_parameter_position

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -20,7 +20,6 @@ disabled_rules:
   - vertical_whitespace
   - void_function_in_ternary
   - empty_enum_arguments
-  - closure_parameter_position
 
 identifier_name:
   min_length: 1


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Removed SwiftLint: warning  _closure_parameter_position_ from .swiftlint.yml file.
-->

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #433
