### PR TITLE
#429 removed trailing_whitespace from disabled rules in .swiftlint.yml

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,7 +16,6 @@ disabled_rules:
   - opening_brace
   - blanket_disable_command
   - for_where
-  - trailing_whitespace
   - vertical_whitespace
   - void_function_in_ternary
   - empty_enum_arguments

--- a/Scribe/AboutTab/InformationScreenVC.swift
+++ b/Scribe/AboutTab/InformationScreenVC.swift
@@ -68,7 +68,7 @@ class InformationScreenVC: UIViewController {
 
     contentContainerView.backgroundColor = UIColor(named: "commandBar")
     applyCornerRadius(elem: contentContainerView, radius: contentContainerView.frame.width * 0.05)
-    
+
 
     cornerImageView.clipsToBounds = true
     contentContainerView.clipsToBounds = true

--- a/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
+++ b/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
@@ -49,7 +49,7 @@ final class InfoChildTableViewCell: UITableViewCell {
 
     return action
   }
-  
+
   // MARK: - Functions
 
   func configureCell(for section: Section) {

--- a/Scribe/ParentTableCellModel.swift
+++ b/Scribe/ParentTableCellModel.swift
@@ -38,7 +38,7 @@ struct Section {
   init(
     sectionTitle: String,
     imageString: String? = nil,
-    hasToggle: Bool = false, 
+    hasToggle: Bool = false,
     hasNestedNavigation: Bool = false,
     sectionState: SectionState,
     shortDescription: String? = nil,


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

Removed `trailing_whitespace` as a disabled rule from [.swiftlint.yml](https://github.com/scribe-org/Scribe-iOS/blob/main/.swiftlint.yml) and fixed all errors for it in the codebase.

**The linter fix was tested running: `swiftlint --no-cache --config ~/com.raywenderlich.swiftlint.yml` and tested on:**
- iPhone 15 Pro Max, iOS 17.4. (simulator)

### Related issue

- #429
