### PR TITLE
Fabuloui os inconsistent command bar outline behavior 423

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -20,7 +20,6 @@ disabled_rules:
   - vertical_whitespace
   - void_function_in_ternary
   - empty_enum_arguments
-  - closure_parameter_position
 
 identifier_name:
   min_length: 1

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
@@ -65,8 +65,6 @@ class CommandBar: UILabel {
     addInfoButton()
     backgroundColor = commandBarColor
     blend.backgroundColor = commandBarColor
-    layer.borderColor = commandBarBorderColor
-    layer.borderWidth = 1.0
     textAlignment = NSTextAlignment.left
     if DeviceType.isPhone {
       font = .systemFont(ofSize: frame.height * 0.4725)

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/ScribeKey.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/ScribeKey.swift
@@ -62,8 +62,6 @@ class ScribeKey: UIButton {
   func set() {
     setImage(scribeKeyIcon, for: .normal)
     setBtn(btn: self, color: commandKeyColor, name: "Scribe", canBeCapitalized: false, isSpecial: false)
-    layer.borderColor = commandBarBorderColor
-    layer.borderWidth = 1.0
     contentMode = .center
     imageView?.contentMode = .scaleAspectFit
     shadow.isUserInteractionEnabled = false


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Removed border from commandBar and ScribeKey to be consistent.
-->

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #423
