### PR TITLE
Fabuloui os fix swift lint warning closure parameter position 434 new

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,7 +19,6 @@ disabled_rules:
   - vertical_whitespace
   - void_function_in_ternary
   - empty_enum_arguments
-  - closure_parameter_position
 
 identifier_name:
   min_length: 1

--- a/Scribe/SettingsTab/SettingsViewController.swift
+++ b/Scribe/SettingsTab/SettingsViewController.swift
@@ -140,7 +140,7 @@ extension SettingsViewController: UITableViewDelegate {
 
         // Languages where we can disable accent keys.
         let accentKeyLanguages: [String] = ["Swedish", "German", "Spanish"]
-        let accentKeyOptionIndex = SettingsTableData.languageSettingsData[0].section.firstIndex(where: { s in 
+        let accentKeyOptionIndex = SettingsTableData.languageSettingsData[0].section.firstIndex(where: { s in
           s.sectionTitle.elementsEqual("Disable accent characters")
         }) ?? -1
 

--- a/Scribe/SettingsTab/SettingsViewController.swift
+++ b/Scribe/SettingsTab/SettingsViewController.swift
@@ -129,8 +129,8 @@ extension SettingsViewController: UITableViewDelegate {
         var data = SettingsTableData.languageSettingsData
 
         // Check if the device is an iPad, and if so don't show the option to put a period and comma on the ABC characters.
-        let periodCommaOptionIndex = SettingsTableData.languageSettingsData[0].section.firstIndex(where: {
-          s in s.sectionTitle.elementsEqual("Period and comma on ABC")
+        let periodCommaOptionIndex = SettingsTableData.languageSettingsData[0].section.firstIndex(where: { s in
+            s.sectionTitle.elementsEqual("Period and comma on ABC")
         }) ?? -1
 
         if DeviceType.isPad {
@@ -140,8 +140,8 @@ extension SettingsViewController: UITableViewDelegate {
 
         // Languages where we can disable accent keys.
         let accentKeyLanguages: [String] = ["Swedish", "German", "Spanish"]
-        let accentKeyOptionIndex = SettingsTableData.languageSettingsData[0].section.firstIndex(where: {
-          s in s.sectionTitle.elementsEqual("Disable accent characters")
+        let accentKeyOptionIndex = SettingsTableData.languageSettingsData[0].section.firstIndex(where: { s in 
+          s.sectionTitle.elementsEqual("Disable accent characters")
         }) ?? -1
 
         if accentKeyLanguages.firstIndex(of: section.sectionTitle) == nil && accentKeyOptionIndex != -1 {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Removed swiftLint warning **closure_parameter_position** from .swiftlint.yml file.
-->

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #433 
