### PR TITLE
Swift lint fix empty enum arguments throughout codebase 432

### DIFF
--- a/.github/workflows/pr_swiftlint.yaml
+++ b/.github/workflows/pr_swiftlint.yaml
@@ -1,6 +1,6 @@
 name: pr_swiftlint
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     types: [opened, reopened, synchronize]

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -18,7 +18,6 @@ disabled_rules:
   - for_where
   - vertical_whitespace
   - void_function_in_ternary
-  - empty_enum_arguments
   - closure_parameter_position
 
 identifier_name:


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Removed swiftlint warning **enum_empty_arguments** from .swiftlint.yml
-->

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #432
