### PR TITLE
fix(ci): correct event type 'pull_request'

### DIFF
--- a/.github/workflows/pr_swiftlint.yaml
+++ b/.github/workflows/pr_swiftlint.yaml
@@ -1,6 +1,6 @@
 name: pr_swiftlint
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     types: [opened, reopened, synchronize]


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Took a quick glance out of curiosity, and thought it odd that no SwiftLint errors were showing up for the following PRs: 
- https://github.com/scribe-org/Scribe-iOS/pull/437
- https://github.com/scribe-org/Scribe-iOS/pull/439

Peeked at what the workflow configuration looked like and noticed the event type. We've run into this before actually in some other small project :smirk: (https://github.com/activist-org/activist/pull/490) 

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- :fist_raised: 
