### PR TITLE
Removed vertical_whitespace from disabled rules in .swiftlint.yml

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,7 +16,6 @@ disabled_rules:
   - opening_brace
   - blanket_disable_command
   - for_where
-  - vertical_whitespace
   - void_function_in_ternary
   - empty_enum_arguments
   - closure_parameter_position

--- a/Scribe/AboutTab/InformationScreenVC.swift
+++ b/Scribe/AboutTab/InformationScreenVC.swift
@@ -69,7 +69,6 @@ class InformationScreenVC: UIViewController {
     contentContainerView.backgroundColor = UIColor(named: "commandBar")
     applyCornerRadius(elem: contentContainerView, radius: contentContainerView.frame.width * 0.05)
 
-
     cornerImageView.clipsToBounds = true
     contentContainerView.clipsToBounds = true
 


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

Removed `trailing_whitespace` as a disabled rule from [.swiftlint.yml](https://github.com/scribe-org/Scribe-iOS/blob/main/.swiftlint.yml) and fixed all errors for it in the codebase.

**The linter fix was tested running: `swiftlint --no-cache --config ~/com.raywenderlich.swiftlint.yml` and tested on:**

- iPhone 15 Pro Max, iOS 17.4. (simulator)

### Related issue

- #430 
