### PR TITLE
Removed opening_brace from disabled rules in .swiftlint.yml

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,7 +13,6 @@ disabled_rules:
   # WARNINGS IN PROJECT CURRENTLY
   - todo
   - orphaned_doc_comment
-  - opening_brace
   - blanket_disable_command
   - for_where
   - vertical_whitespace

--- a/Keyboards/KeyboardsBase/KeyAnimation.swift
+++ b/Keyboards/KeyboardsBase/KeyAnimation.swift
@@ -274,12 +274,10 @@ func getKeyPopPath(key: UIButton, layer: CAShapeLayer, char: String, displayChar
     var labelVertPosition = frame.origin.y - key.frame.height / 1.75
     // non-capital characters should be higher for portrait phone views.
     if displayChar == char, DeviceType.isPhone, !isLandscapeView,
-       !["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"].contains(char)
-    {
+       !["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"].contains(char) {
       labelVertPosition = frame.origin.y - key.frame.height / 1.6
     } else if DeviceType.isPad,
-              isLandscapeView
-    {
+              isLandscapeView {
       labelVertPosition = frame.origin.y - key.frame.height / 2
     }
 

--- a/Keyboards/KeyboardsBase/KeyboardKeys.swift
+++ b/Keyboards/KeyboardsBase/KeyboardKeys.swift
@@ -72,8 +72,7 @@ class KeyboardKey: UIButton {
       && key != spaceBar
       && key != languageTextForSpaceBar
       && key != "ABC"
-      && key != "АБВ"
-    {
+      && key != "АБВ" {
       capsKey = keyboard[row][idx].capitalized
     } else {
       capsKey = key
@@ -102,8 +101,7 @@ class KeyboardKey: UIButton {
       if key == "#+="
         || key == "ABC"
         || key == "АБВ"
-        || key == "123"
-      {
+        || key == "123" {
         titleLabel?.font = .systemFont(ofSize: letterKeyWidth / 3.5)
       } else if key == spaceBar || key == languageTextForSpaceBar {
         titleLabel?.font = .systemFont(ofSize: letterKeyWidth / 4)
@@ -114,8 +112,7 @@ class KeyboardKey: UIButton {
       if key == "#+="
         || key == "ABC"
         || key == "АБВ"
-        || key == "123"
-      {
+        || key == "123" {
         titleLabel?.font = .systemFont(ofSize: letterKeyWidth / 1.75)
       } else if key == spaceBar || key == languageTextForSpaceBar {
         titleLabel?.font = .systemFont(ofSize: letterKeyWidth / 2)
@@ -132,8 +129,7 @@ class KeyboardKey: UIButton {
     if keyboardState == .letters
       && !isSpecial
       && !["123", "´", spaceBar, languageTextForSpaceBar].contains(key)
-      && shiftButtonState == .normal
-    {
+      && shiftButtonState == .normal {
       titleEdgeInsets = UIEdgeInsets(top: -4.0, left: 0.0, bottom: 0.0, right: 0.0)
 
       if isLandscapeView {
@@ -158,8 +154,7 @@ class KeyboardKey: UIButton {
       if key == "#+="
         || key == "ABC"
         || key == "АБВ"
-        || key == "hideKeyboard"
-      {
+        || key == "hideKeyboard" {
         titleLabel?.font = .systemFont(ofSize: letterKeyWidth / 3.75)
       } else if key == spaceBar || key == languageTextForSpaceBar {
         titleLabel?.font = .systemFont(ofSize: letterKeyWidth / 4.25)
@@ -172,8 +167,7 @@ class KeyboardKey: UIButton {
       if key == "#+="
         || key == "ABC"
         || key == "АБВ"
-        || key == "hideKeyboard"
-      {
+        || key == "hideKeyboard" {
         titleLabel?.font = .systemFont(ofSize: letterKeyWidth / 3.25)
       } else if key == spaceBar || key == languageTextForSpaceBar {
         titleLabel?.font = .systemFont(ofSize: letterKeyWidth / 3.5)
@@ -192,8 +186,7 @@ class KeyboardKey: UIButton {
     if keyboardState == .letters
       && !isSpecial
       && ![".?123", spaceBar, languageTextForSpaceBar, "ß", "´", ",", ".", "'", "-"].contains(key)
-      && shiftButtonState == .normal
-    {
+      && shiftButtonState == .normal {
       titleEdgeInsets = UIEdgeInsets(top: -4.0, left: 0.0, bottom: 0.0, right: 0.0)
 
       if isLandscapeView {
@@ -229,13 +222,11 @@ class KeyboardKey: UIButton {
     } else if key == "delete"
       || key == "#+="
       || key == "shift"
-      || key == "selectKeyboard"
-    {
+      || key == "selectKeyboard" {
       // Cancel Russian keyboard key resizing if translating as the keyboard is English.
       if controllerLanguage == "Russian"
         && keyboardState == .letters
-        && commandState != .translate
-      {
+        && commandState != .translate {
         layer.setValue(true, forKey: "isSpecial")
         widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1).isActive = true
       } else {
@@ -245,8 +236,7 @@ class KeyboardKey: UIButton {
     } else if key == "123"
       || key == ".?123"
       || key == "return"
-      || key == "hideKeyboard"
-    {
+      || key == "hideKeyboard" {
       if row == 2 {
         layer.setValue(true, forKey: "isSpecial")
         widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.5).isActive = true
@@ -255,8 +245,7 @@ class KeyboardKey: UIButton {
         widthAnchor.constraint(equalToConstant: numSymKeyWidth * 2).isActive = true
       }
     } else if (keyboardState == .numbers || keyboardState == .symbols)
-      && row == 2
-    {
+      && row == 2 {
       // Make second row number and symbol keys wider for iPhones.
       widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.4).isActive = true
     } else if key != spaceBar && key != languageTextForSpaceBar {
@@ -301,8 +290,7 @@ class KeyboardKey: UIButton {
         if key == "return"
           && (controllerLanguage == "Portuguese" || controllerLanguage == "Italian" || commandState == .translate)
           && row == 1
-          && DeviceType.isPad
-        {
+          && DeviceType.isPad {
           layer.setValue(true, forKey: "isSpecial")
           widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarReturnKeyWidth).isActive = true
         } else {
@@ -323,8 +311,7 @@ class KeyboardKey: UIButton {
         if key == "return"
           && (controllerLanguage == "Portuguese" || controllerLanguage == "Italian" || commandState == .translate)
           && row == 1
-          && DeviceType.isPad
-        {
+          && DeviceType.isPad {
           layer.setValue(true, forKey: "isSpecial")
           widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.5).isActive = true
         } else {

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -418,8 +418,7 @@ class KeyboardViewController: UIInputViewController {
         currentPrefix = inString.replacingOccurrences(of: pastStringInTextProxy, with: "")
 
         if currentPrefix.hasPrefix("(") || currentPrefix.hasPrefix("#") ||
-          currentPrefix.hasPrefix("/") || currentPrefix.hasPrefix("\"")
-        {
+          currentPrefix.hasPrefix("/") || currentPrefix.hasPrefix("\"") {
           currentPrefix = currentPrefix.replacingOccurrences(of: #"[\"(#\/]"#, with: "", options: .regularExpression)
         }
 
@@ -872,8 +871,7 @@ class KeyboardViewController: UIInputViewController {
     conditionallyDisplayAnnotation()
     if (keyPressed == phoneEmojiKey0 || keyPressed == phoneEmojiKey1)
       || (keyPressed == padEmojiKey0 || keyPressed == padEmojiKey1 || keyPressed == padEmojiKey2)
-      || (keyPressed == pluralKey && emojisToShow == .one)
-    {
+      || (keyPressed == pluralKey && emojisToShow == .one) {
       emojiAutoActionRepeatPossible = true
     }
   }
@@ -1357,8 +1355,7 @@ class KeyboardViewController: UIInputViewController {
       }
 
       if controllerLanguage == "German"
-        && [.accusativeIndefinite, .dativeIndefinite, .genitiveIndefinite].contains(deCaseDeclensionState)
-      {
+        && [.accusativeIndefinite, .dativeIndefinite, .genitiveIndefinite].contains(deCaseDeclensionState) {
         formKeyBR.isUserInteractionEnabled = false
       }
 
@@ -1636,8 +1633,7 @@ class KeyboardViewController: UIInputViewController {
         if DeviceType.isPhone
           && key == "y"
           && ["German", "Swedish"].contains(controllerLanguage)
-          && commandState != .translate
-        {
+          && commandState != .translate {
           leftPadding = keyWidth / 3
           addPadding(to: stackView2, width: leftPadding, key: "y")
         }
@@ -1645,8 +1641,7 @@ class KeyboardViewController: UIInputViewController {
           && key == "a"
           && (controllerLanguage == "Portuguese"
             || controllerLanguage == "Italian"
-            || commandState == .translate)
-        {
+            || commandState == .translate) {
           leftPadding = keyWidth / 4
           addPadding(to: stackView1, width: leftPadding, key: "a")
         }
@@ -1655,8 +1650,7 @@ class KeyboardViewController: UIInputViewController {
           && !usingExpandedKeyboard
           && (controllerLanguage == "Portuguese"
             || controllerLanguage == "Italian"
-            || commandState == .translate)
-        {
+            || commandState == .translate) {
           leftPadding = keyWidth / 3
           addPadding(to: stackView1, width: leftPadding, key: "a")
         }
@@ -1665,8 +1659,7 @@ class KeyboardViewController: UIInputViewController {
           && !usingExpandedKeyboard
           && (controllerLanguage == "Portuguese"
             || controllerLanguage == "Italian"
-            || commandState == .translate)
-        {
+            || commandState == .translate) {
           leftPadding = keyWidth / 3
           addPadding(to: stackView1, width: leftPadding, key: "@")
         }
@@ -1674,8 +1667,7 @@ class KeyboardViewController: UIInputViewController {
           && key == "€"
           && !usingExpandedKeyboard
           && (controllerLanguage == "Portuguese"
-            || commandState == .translate)
-        {
+            || commandState == .translate) {
           leftPadding = keyWidth / 3
           addPadding(to: stackView1, width: leftPadding, key: "€")
         }
@@ -1763,8 +1755,7 @@ class KeyboardViewController: UIInputViewController {
         if DeviceType.isPhone
           && key == "m"
           && ["German", "Swedish"].contains(controllerLanguage)
-          && commandState != .translate
-        {
+          && commandState != .translate {
           rightPadding = keyWidth / 3
           addPadding(to: stackView2, width: rightPadding, key: "m")
         }
@@ -1772,8 +1763,7 @@ class KeyboardViewController: UIInputViewController {
           && key == "l"
           && (controllerLanguage == "Portuguese"
             || controllerLanguage == "Italian"
-            || commandState == .translate)
-        {
+            || commandState == .translate) {
           rightPadding = keyWidth / 4
           addPadding(to: stackView1, width: rightPadding, key: "l")
         }
@@ -2187,8 +2177,7 @@ class KeyboardViewController: UIInputViewController {
             .conjugate,
             .selectVerbConjugation,
             .selectCaseDeclension,
-            .plural].contains(commandState)
-        { // escape
+            .plural].contains(commandState) { // escape
           commandState = .idle
           deCaseVariantDeclensionState = .disabled
         } else if [.idle, .alreadyPlural, .invalid].contains(commandState) { // ScribeKey
@@ -2723,8 +2712,7 @@ class KeyboardViewController: UIInputViewController {
       if touch.tapCount == 2
         && (originalKey == spaceBar || originalKey == languageTextForSpaceBar)
         && proxy.documentContextBeforeInput?.count != 1
-        && doubleSpacePeriodPossible
-      {
+        && doubleSpacePeriodPossible {
         // The fist condition prevents a period if the prior characters are spaces as the user wants a series of spaces.
         if proxy.documentContextBeforeInput?.suffix(2) != "  " && ![.translate, .conjugate, .plural].contains(commandState) {
           proxy.deleteBackward()

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
@@ -195,8 +195,7 @@ func returnDeclension(keyPressed: UIButton) {
 func triggerVerbConjugation(commandBar: UILabel) -> Bool {
   // Cancel via a return press.
   if let commandBarText = commandBar.text,
-     commandBarText == conjugatePromptAndCursor || commandBarText == conjugatePromptAndCursor
-  {
+     commandBarText == conjugatePromptAndCursor || commandBarText == conjugatePromptAndCursor {
     return false
   }
 

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Plural.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Plural.swift
@@ -26,8 +26,7 @@ import UIKit
 func queryPlural(commandBar: UILabel) {
   // Cancel via a return press.
   if let commandBarText = commandBar.text,
-     commandBarText == pluralPromptAndCursor || commandBarText == pluralPromptAndCursor
-  {
+     commandBarText == pluralPromptAndCursor || commandBarText == pluralPromptAndCursor {
     return
   }
 

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
@@ -26,8 +26,7 @@ import UIKit
 func queryTranslation(commandBar: UILabel) {
   // Cancel via a return press.
   if let commandBarText = commandBar.text,
-     commandBarText == translatePromptAndCursor || commandBarText == translatePromptAndPlaceholder
-  {
+     commandBarText == translatePromptAndCursor || commandBarText == translatePromptAndPlaceholder {
     return
   }
 


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

Removed `opening_brace` as a disabled rule from [.swiftlint.yml](https://github.com/scribe-org/Scribe-iOS/blob/main/.swiftlint.yml) and fixed all errors for it in the codebase.

**The linter fix was tested running: `swiftlint --no-cache --config ~/com.raywenderlich.swiftlint.yml` and tested on:**

- iPhone 15 Pro Max, iOS 17.4. (simulator)

### Related issue

- #426 
