### PR TITLE
Removed void_function_in_ternary from disabled rules in .swiftint.yml

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,7 +17,6 @@ disabled_rules:
   - blanket_disable_command
   - for_where
   - vertical_whitespace
-  - void_function_in_ternary
   - empty_enum_arguments
   - closure_parameter_position
 

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -2571,7 +2571,11 @@ class KeyboardViewController: UIInputViewController {
       capsLockPossible = true
 
     case "123", ".?123":
-      usingExpandedKeyboard == true ? changeKeyboardToSymbolKeys() : changeKeyboardToNumberKeys()
+    if usingExpandedKeyboard {
+        changeKeyboardToSymbolKeys()
+    } else {
+        changeKeyboardToNumberKeys()
+    }
 
     case "#+=":
       changeKeyboardToSymbolKeys()


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

Removed `void_function_in_ternary` as a disabled rule from [.swiftlint.yml](https://github.com/scribe-org/Scribe-iOS/blob/main/.swiftlint.yml) and fixed all errors for it in the codebase.

**The linter fix was tested running: `swiftlint --no-cache --config ~/com.raywenderlich.swiftlint.yml` and tested on:**

- iPhone 15 Pro Max, iOS 17.4. (simulator)

### Related issue

- #431 
