### PR TITLE
Remove accent characters menu option from i pads 477

### DIFF
--- a/Keyboards/KeyboardsBase/InterfaceVariables.swift
+++ b/Keyboards/KeyboardsBase/InterfaceVariables.swift
@@ -22,7 +22,7 @@ import UIKit
 // A proxy into which text is typed.
 var proxy: UITextDocumentProxy!
 
-// MARK: - Display Variables
+// MARK: Display Variables
 
 // Variables for the keyboard and its appearance.
 var keyboard = [[String]]()

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -91,7 +91,7 @@ class KeyboardViewController: UIInputViewController {
     loadKeys()
   }
 
-  // MARK: - Display Activation Functions
+  // MARK: Display Activation Functions
 
   /// Function to load the keyboard interface into which keyboardView is instantiated.
   func loadInterface() {
@@ -138,7 +138,7 @@ class KeyboardViewController: UIInputViewController {
     btn.isUserInteractionEnabled = false
   }
 
-  // MARK: - Override UIInputViewController Functions
+  // MARK: Override UIInputViewController Functions
 
   /// Includes adding custom view sizing constraints.
   override func updateViewConstraints() {
@@ -260,7 +260,7 @@ class KeyboardViewController: UIInputViewController {
     }
   }
 
-  // MARK: - Scribe Command Elements
+  // MARK: Scribe Command Elements
 
   // Partitions for autocomplete and autosuggest
   @IBOutlet var leftAutoPartition: UILabel!
@@ -951,7 +951,7 @@ class KeyboardViewController: UIInputViewController {
     }
   }
 
-  // MARK: - Conjugation Variables and Functions
+  // MARK: Conjugation Variables and Functions
 
   // Note that we use "form" to describe both conjugations and declensions.
   @IBOutlet var shiftFormsDisplayLeft: UIButton!
@@ -2170,7 +2170,7 @@ class KeyboardViewController: UIInputViewController {
     }
   }
 
-  // MARK: - Button Actions
+  // MARK: Button Actions
 
   /// Triggers actions based on the press of a key.
   ///
@@ -2680,7 +2680,7 @@ class KeyboardViewController: UIInputViewController {
     }
   }
 
-  // MARK: - Key Press Functions
+  // MARK: Key Press Functions
 
   /// Auto-capitalization if the cursor is at the start of the proxy.
   func autoCapAtStartOfProxy() {

--- a/Keyboards/KeyboardsBase/LanguageDBManager.swift
+++ b/Keyboards/KeyboardsBase/LanguageDBManager.swift
@@ -173,7 +173,7 @@ class LanguageDBManager {
   }
 }
 
-// MARK: - Database operations
+// MARK: Database operations
 
 extension LanguageDBManager {
   /// Delete non-unique values in case the lexicon has added words that were already present.

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
@@ -21,7 +21,7 @@ import UIKit
 
 /// A custom UILabel used to house all the functionality of the command bar.
 class CommandBar: UILabel {
-  // MARK: - Internal Properties
+  // MARK: Internal Properties
 
   /// Button that is shown on the trailing edge of the command bar.
   let infoButton = UIButton(type: .system)
@@ -35,7 +35,7 @@ class CommandBar: UILabel {
     }
   }
 
-  // MARK: - Initializer
+  // MARK: Initializer
 
   override init(frame: CGRect) {
     super.init(frame: frame)
@@ -57,7 +57,7 @@ class CommandBar: UILabel {
 
   var shadow: UIButton!
 
-  // MARK: - Internal methods
+  // MARK: Internal methods
 
   /// Sets up the command bar's color and text alignment.
   func set() {

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
@@ -93,7 +93,7 @@ var allColoredPrompts: [NSAttributedString] = []
 let languagesWithCapitalizedNouns = ["German"]
 let languagesWithCaseDependantOnPrepositions = ["German", "Russian"]
 
-// MARK: - Translate Variables
+// MARK: Translate Variables
 
 var translateKeyLbl = ""
 var translatePrompt = ""
@@ -103,7 +103,7 @@ var translatePromptAndPlaceholder = ""
 var translatePromptAndColorPlaceholder = NSMutableAttributedString()
 var wordToTranslate = ""
 
-// MARK: - Conjugate Variables
+// MARK: Conjugate Variables
 
 var conjugateKeyLbl = ""
 var conjugatePrompt = ""
@@ -171,7 +171,7 @@ var verbToDisplay = ""
 var wordToDisplay = ""
 var conjugationToDisplay = ""
 
-// MARK: - Plural Variables
+// MARK: Plural Variables
 
 var pluralKeyLbl = ""
 var pluralPrompt = ""

--- a/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewDatasource.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewDatasource.swift
@@ -23,7 +23,7 @@ struct ToolTipViewDatasource: ToolTipViewDatasourceable {
   var theme: ViewThemeable
   private var content: NSMutableAttributedString
 
-  // MARK: - Init
+  // MARK: Init
 
   init(content: NSMutableAttributedString, theme: ViewThemeable) {
     self.content = content

--- a/Keyboards/KeyboardsBase/ToolTip/ToolTipView.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/ToolTipView.swift
@@ -22,7 +22,7 @@ import UIKit
 final class ToolTipView: UIView, ToolTipViewUpdatable {
   var didUpdatePage: ((ConjViewShiftButtonsState) -> Void)?
 
-  // MARK: - Private propeties
+  // MARK: Private propeties
 
   private var currentIndex: Int = 0 {
     didSet {
@@ -38,7 +38,7 @@ final class ToolTipView: UIView, ToolTipViewUpdatable {
 
   private var datasources: [ToolTipViewDatasourceable]
 
-  // MARK: - Private UI
+  // MARK: Private UI
 
   private(set) lazy var contentLabel: UILabel = {
     let tempLabel = UILabel()
@@ -64,7 +64,7 @@ final class ToolTipView: UIView, ToolTipViewUpdatable {
 
   private(set) var pageControl = UIPageControl()
 
-  // MARK: - Init
+  // MARK: Init
 
   init(datasources: [ToolTipViewDatasourceable]) {
     self.datasources = datasources
@@ -85,7 +85,7 @@ final class ToolTipView: UIView, ToolTipViewUpdatable {
     fatalError("init(coder:) has not been implemented")
   }
 
-  // MARK: - Overrides
+  // MARK: Overrides
 
   override func layoutSubviews() {
     let datasource = getCurrentDatasource()
@@ -103,7 +103,7 @@ final class ToolTipView: UIView, ToolTipViewUpdatable {
     }
   }
 
-  // MARK: - Methods
+  // MARK: Methods
 
   func updateNext() {
     let tempCurrentIndex = currentIndex + 1
@@ -126,7 +126,7 @@ final class ToolTipView: UIView, ToolTipViewUpdatable {
     animateDatasourceChange(newDatasource: newDatasource)
   }
 
-  // MARK: - Private methods
+  // MARK: Private methods
 
   private func getCurrentDatasource() -> ToolTipViewDatasourceable {
     datasources[currentIndex]

--- a/Scribe/AboutTab/AboutViewController.swift
+++ b/Scribe/AboutTab/AboutViewController.swift
@@ -57,7 +57,7 @@ final class AboutViewController: BaseTableViewController {
   }
 }
 
-// MARK: - UITableViewDataSource
+// MARK: UITableViewDataSource
 
 extension AboutViewController {
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -74,7 +74,7 @@ extension AboutViewController {
   }
 }
 
-// MARK: - UITableViewDelegate
+// MARK: UITableViewDelegate
 
 extension AboutViewController {
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -197,7 +197,7 @@ extension AboutViewController {
   }
 }
 
-// MARK: - MFMailComposeViewControllerDelegate
+// MARK: MFMailComposeViewControllerDelegate
 
 extension AboutViewController: MFMailComposeViewControllerDelegate {
   func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith _: MFMailComposeResult, error _: Error?) {
@@ -205,7 +205,7 @@ extension AboutViewController: MFMailComposeViewControllerDelegate {
   }
 }
 
-// MARK: - TipCardView
+// MARK: TipCardView
 extension AboutViewController {
   private func showTipCardView() {
     let overlayView = AboutTipCardView(

--- a/Scribe/AppDelegate.swift
+++ b/Scribe/AppDelegate.swift
@@ -91,7 +91,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     saveContext()
   }
 
-  // MARK: - Core Data stack
+  // MARK: Core Data stack
 
   lazy var persistentContainer: NSPersistentContainer = {
     /*
@@ -124,7 +124,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     return container
   }()
 
-  // MARK: - Core Data Saving support
+  // MARK: Core Data Saving support
 
   func saveContext() {
     let context = persistentContainer.viewContext

--- a/Scribe/Colors/UIColor+ScribeColors.swift
+++ b/Scribe/Colors/UIColor+ScribeColors.swift
@@ -20,7 +20,7 @@
 import UIKit
 
 extension UIColor {
-  // MARK: - Init from ScribeColor
+  // MARK: Init from ScribeColor
 
   /// Creates `UIColor` from passed `ScribeColor`
   /// - Parameter color: The `UIColor`.

--- a/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
+++ b/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
@@ -21,11 +21,11 @@ import UIKit
 
 final class InfoChildTableViewCell: UITableViewCell {
 
-  // MARK: - Constants
+  // MARK: Constants
 
   static let reuseIdentifier = String(describing: InfoChildTableViewCell.self)
 
-  // MARK: - Properties
+  // MARK: Properties
 
   @IBOutlet var titleLabelPhone: UILabel!
   @IBOutlet var titleLabelPad: UILabel!
@@ -78,7 +78,7 @@ final class InfoChildTableViewCell: UITableViewCell {
     return action
   }
 
-  // MARK: - Functions
+  // MARK: Functions
 
   func configureCell(for section: Section) {
     self.section = section

--- a/Scribe/Components/TableViewTemplateViewController.swift
+++ b/Scribe/Components/TableViewTemplateViewController.swift
@@ -20,7 +20,7 @@
 import UIKit
 
 final class TableViewTemplateViewController: BaseTableViewController {
-  // MARK: - Properties
+  // MARK: Properties
 
   override var dataSet: [ParentTableCellModel] {
     tableData
@@ -41,7 +41,7 @@ final class TableViewTemplateViewController: BaseTableViewController {
     return lang
   }
 
-  // MARK: - Functions
+  // MARK: Functions
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -59,7 +59,7 @@ final class TableViewTemplateViewController: BaseTableViewController {
   }
 }
 
-// MARK: - UITableViewDataSource
+// MARK: UITableViewDataSource
 
 extension TableViewTemplateViewController {
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Scribe/Components/UITableViewCells/AboutTableViewCell.swift
+++ b/Scribe/Components/UITableViewCells/AboutTableViewCell.swift
@@ -21,11 +21,11 @@ import UIKit
 
 final class AboutTableViewCell: UITableViewCell {
 
-  // MARK: - Constants
+  // MARK: Constants
 
   static let reuseIdentifier = String(describing: InfoChildTableViewCell.self)
 
-  // MARK: - Properties
+  // MARK: Properties
 
   @IBOutlet var titleLabelPhone: UILabel!
   @IBOutlet var titleLabelPad: UILabel!
@@ -62,7 +62,7 @@ final class AboutTableViewCell: UITableViewCell {
     }
   }
 
-  // MARK: - Functions
+  // MARK: Functions
 
   func configureCell(for section: Section) {
     selectionStyle = .none

--- a/Scribe/Extensions/UIEdgeInsetsExtensions.swift
+++ b/Scribe/Extensions/UIEdgeInsetsExtensions.swift
@@ -21,7 +21,7 @@ import UIKit
 
 extension UIEdgeInsets {
 
-  // MARK: - Initialisation
+  // MARK: Initialisation
 
   init(vertical: CGFloat, horizontal: CGFloat) {
     self.init(top: vertical, left: horizontal, bottom: vertical, right: horizontal)

--- a/Scribe/InstallationTab/DownloadDataVC.swift
+++ b/Scribe/InstallationTab/DownloadDataVC.swift
@@ -64,7 +64,7 @@ import UIKit
 // }
 //
 
-// MARK: - UITableViewDelegate
+// MARK: UITableViewDelegate
 
 //
 ///// Function implementation conforming to the UITableViewDelegate protocol.

--- a/Scribe/InstallationTab/InstallationVC.swift
+++ b/Scribe/InstallationTab/InstallationVC.swift
@@ -278,7 +278,7 @@ class InstallationVC: UIViewController {
   }
 }
 
-// MARK: - TipHintView
+// MARK: TipHintView
 
 extension InstallationVC {
   private func showTipCardView() {

--- a/Scribe/SettingsTab/SettingsViewController.swift
+++ b/Scribe/SettingsTab/SettingsViewController.swift
@@ -167,10 +167,10 @@ extension SettingsViewController: UITableViewDelegate {
       ) as? TableViewTemplateViewController {
         // Copy base settings.
         var data = SettingsTableData.languageSettingsData
+        // Check if the device is an iPad to remove the Layout Section.
         if DeviceType.isPad {
           data.remove(at: 0)
         } else {
-          // Check if the device is an iPad to determine period and comma on the ABC characters option.
           let periodCommaOptionIndex = SettingsTableData.languageSettingsData[0].section.firstIndex(where: { s in
             s.sectionTitle.elementsEqual(NSLocalizedString("app.settings.layout.periodAndComma", value: "Period and comma on ABC", comment: ""))
           }) ?? -1

--- a/Scribe/SettingsTab/SettingsViewController.swift
+++ b/Scribe/SettingsTab/SettingsViewController.swift
@@ -167,35 +167,33 @@ extension SettingsViewController: UITableViewDelegate {
       ) as? TableViewTemplateViewController {
         // Copy base settings.
         var data = SettingsTableData.languageSettingsData
-
-        // Check if the device is an iPad to determine period and comma on the ABC characters option.
-        let periodCommaOptionIndex = SettingsTableData.languageSettingsData[0].section.firstIndex(where: { s in
-          s.sectionTitle.elementsEqual(NSLocalizedString("app.settings.layout.periodAndComma", value: "Period and comma on ABC", comment: ""))
-        }) ?? -1
-
         if DeviceType.isPad {
-          let periodCommaSettings = data[0].section.remove(at: periodCommaOptionIndex)
-          print(periodCommaSettings)
-        }
+          data.remove(at: 0)
+        } else {
+          // Check if the device is an iPad to determine period and comma on the ABC characters option.
+          let periodCommaOptionIndex = SettingsTableData.languageSettingsData[0].section.firstIndex(where: { s in
+            s.sectionTitle.elementsEqual(NSLocalizedString("app.settings.layout.periodAndComma", value: "Period and comma on ABC", comment: ""))
+          }) ?? -1
 
-        // Languages where we can disable accent keys.
-        let accentKeyLanguages: [String] = ["Swedish", "German", "Spanish"]
-        let accentKeyOptionIndex = SettingsTableData.languageSettingsData[0].section.firstIndex(where: { s in
-          s.sectionTitle.elementsEqual(NSLocalizedString("app.settings.layout.disableAccentCharacters", value: "Disable accent characters", comment: ""))
-        }) ?? -1
+          // Languages where we can disable accent keys.
+          let accentKeyLanguages: [String] = ["Swedish", "German", "Spanish"]
+          let accentKeyOptionIndex = SettingsTableData.languageSettingsData[0].section.firstIndex(where: { s in
+            s.sectionTitle.elementsEqual(NSLocalizedString("app.settings.layout.disableAccentCharacters", value: "Disable accent characters", comment: ""))
+          }) ?? -1
 
-        // If there are no accent keys we can remove the `Disable accent characters` option.
-        if accentKeyLanguages.firstIndex(of: section.sectionTitle) == nil && accentKeyOptionIndex != -1 {
-          let accentKeySettings = data[0].section.remove(at: accentKeyOptionIndex)
-          print(accentKeySettings)
-        } else if accentKeyLanguages.firstIndex(of: section.sectionTitle) != nil && accentKeyOptionIndex == -1 {
-          data[0].section.insert(Section(
+          // If there are no accent keys we can remove the `Disable accent characters` option.
+          if accentKeyLanguages.firstIndex(of: section.sectionTitle) == nil && accentKeyOptionIndex != -1 {
+            let accentKeySettings = data[0].section.remove(at: accentKeyOptionIndex)
+            print(accentKeySettings)
+          } else if accentKeyLanguages.firstIndex(of: section.sectionTitle) != nil && accentKeyOptionIndex == -1 {
+            data[0].section.insert(Section(
               sectionTitle: NSLocalizedString("app.settings.layout.disableAccentCharacters", value: "Disable accent characters", comment: ""),
               imageString: "info.circle",
               hasToggle: true,
               sectionState: .none(.toggleAccentCharacters)
             ), at: 1
-          )
+            )
+          }
         }
 
         viewController.configureTable(for: data, parentSection: section)

--- a/Scribe/SettingsTab/SettingsViewController.swift
+++ b/Scribe/SettingsTab/SettingsViewController.swift
@@ -169,7 +169,15 @@ extension SettingsViewController: UITableViewDelegate {
         var data = SettingsTableData.languageSettingsData
         // Check if the device is an iPad to remove the Layout Section.
         if DeviceType.isPad {
-          data.remove(at: 0)
+          for menuOption in data[0].section {
+            if menuOption.sectionState == .none(.toggleAccentCharacters) ||
+                menuOption.sectionState == .none(.toggleCommaAndPeriod) {
+              data[0].section.remove(at: 0)
+            }
+          }
+          if data[0].section.isEmpty {
+            data.remove(at: 0)
+          }
         } else {
           let periodCommaOptionIndex = SettingsTableData.languageSettingsData[0].section.firstIndex(where: { s in
             s.sectionTitle.elementsEqual(NSLocalizedString("app.settings.layout.periodAndComma", value: "Period and comma on ABC", comment: ""))

--- a/Scribe/SettingsTab/SettingsViewController.swift
+++ b/Scribe/SettingsTab/SettingsViewController.swift
@@ -21,7 +21,7 @@ import UIKit
 import SwiftUI
 
 final class SettingsViewController: UIViewController {
-  // MARK: - Constants
+  // MARK: Constants
 
   private var sectionHeaderHeight: CGFloat = 0
   private let separatorInset = UIEdgeInsets(top: 16.0, left: 16.0, bottom: 16.0, right: 16.0)
@@ -40,7 +40,7 @@ final class SettingsViewController: UIViewController {
     }
   }
 
-  // MARK: - Properties
+  // MARK: Properties
 
   @IBOutlet var footerFrame: UIView!
   @IBOutlet var footerButton: UIButton!
@@ -48,7 +48,7 @@ final class SettingsViewController: UIViewController {
 
   var tableData = SettingsTableData.settingsTableData
 
-  // MARK: - Functions
+  // MARK: Functions
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -121,7 +121,7 @@ final class SettingsViewController: UIViewController {
   }
 }
 
-// MARK: - UITableViewDataSource
+// MARK: UITableViewDataSource
 
 extension SettingsViewController: UITableViewDataSource {
   func numberOfSections(in _: UITableView) -> Int {
@@ -150,7 +150,7 @@ extension SettingsViewController: UITableViewDataSource {
   }
 }
 
-// MARK: - UITableViewDelegate
+// MARK: UITableViewDelegate
 
 extension SettingsViewController: UITableViewDelegate {
   func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -260,7 +260,7 @@ extension SettingsViewController: UITableViewDelegate {
   }
 }
 
-// MARK: - TipCardView
+// MARK: TipCardView
 extension SettingsViewController {
   private func showTipCardView() {
     let overlayView = SettingsTipCardView(
@@ -292,11 +292,12 @@ extension SettingsViewController {
     view.layer.shadowOpacity = 0.0
     view.layer.shadowOffset = CGSize(width: 0, height: 0)
 
-    UIView.animate(withDuration: duration,
-                   delay: 0,
-                   options: [.curveEaseOut, .autoreverse],
-                   animations: {
-      view.layer.shadowOpacity = 0.6
-    }, completion: nil)
+    UIView.animate(
+      withDuration: duration,
+      delay: 0,
+      options: [.curveEaseOut, .autoreverse],
+      animations: {
+        view.layer.shadowOpacity = 0.6
+      }, completion: nil)
   }
 }

--- a/Scribe/Views/BaseTableViewController.swift
+++ b/Scribe/Views/BaseTableViewController.swift
@@ -21,7 +21,7 @@ import SwipeableTabBarController
 import UIKit
 
 class BaseTableViewController: UITableViewController {
-  // MARK: - Constants
+  // MARK: Constants
 
   private var sectionHeaderHeight: CGFloat = 0
   private let separatorInset = UIEdgeInsets(top: 16.0, left: 16.0, bottom: 16.0, right: 16.0)
@@ -34,13 +34,13 @@ class BaseTableViewController: UITableViewController {
     }
   }
 
-  // MARK: - Properties
+  // MARK: Properties
 
   var dataSet: [ParentTableCellModel] {
     []
   }
 
-  // MARK: - Functions
+  // MARK: Functions
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -58,7 +58,7 @@ class BaseTableViewController: UITableViewController {
   }
 }
 
-// MARK: - UITableViewDataSource
+// MARK: UITableViewDataSource
 
 extension BaseTableViewController {
   override func numberOfSections(in _: UITableView) -> Int {
@@ -70,7 +70,7 @@ extension BaseTableViewController {
   }
 }
 
-// MARK: - UITableViewDelegate
+// MARK: UITableViewDelegate
 
 extension BaseTableViewController {
   override func tableView(_: UITableView, viewForHeaderInSection section: Int) -> UIView? {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

Implemented a check for iPad to remove **Layout** section from langSpecific settings.

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #477 
