### PR TITLE
Enter selected text into Scribe

### DIFF
--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -2199,32 +2199,23 @@ class KeyboardViewController: UIInputViewController {
 
     switch originalKey {
     case "Scribe":
-      if proxy.selectedText != nil && [.idle, .selectCommand, .alreadyPlural, .invalid].contains(commandState) { // annotate word
-        if [.selectCommand, .alreadyPlural, .invalid].contains(commandState) {
-          commandState = .idle
-        }
-        emojisToShow = .zero
-        loadKeys()
-        selectedWordAnnotation(KVC: self)
-      } else {
-        if [.translate,
-            .conjugate,
-            .selectVerbConjugation,
-            .selectCaseDeclension,
-            .plural].contains(commandState) { // escape
-          commandState = .idle
-          deCaseVariantDeclensionState = .disabled
-        } else if [.idle, .alreadyPlural, .invalid].contains(commandState) { // ScribeKey
-          commandState = .selectCommand
-          activateBtn(btn: translateKey)
-          activateBtn(btn: conjugateKey)
-          activateBtn(btn: pluralKey)
-        } else { // escape
-          commandState = .idle
-          deCaseVariantDeclensionState = .disabled
-        }
-        loadKeys()
+      if [.translate,
+          .conjugate,
+          .selectVerbConjugation,
+          .selectCaseDeclension,
+          .plural].contains(commandState) { // escape
+        commandState = .idle
+        deCaseVariantDeclensionState = .disabled
+      } else if [.idle, .alreadyPlural, .invalid].contains(commandState) { // ScribeKey
+        commandState = .selectCommand
+        activateBtn(btn: translateKey)
+        activateBtn(btn: conjugateKey)
+        activateBtn(btn: pluralKey)
+      } else { // escape
+        commandState = .idle
+        deCaseVariantDeclensionState = .disabled
       }
+      loadKeys()
 
     case "return":
       if ![.translate, .conjugate, .plural].contains(commandState) { // normal return button
@@ -2283,6 +2274,9 @@ class KeyboardViewController: UIInputViewController {
       loadKeys()
       commandBar.textColor = keyCharColor
       commandBar.attributedText = translatePromptAndColorPlaceholder
+      if let selectedText = proxy.selectedText {
+        commandBar.text = translatePrompt + selectedText + commandCursor
+      }
 
     case "Conjugate":
       commandState = .conjugate
@@ -2290,6 +2284,9 @@ class KeyboardViewController: UIInputViewController {
       loadKeys()
       commandBar.textColor = keyCharColor
       commandBar.attributedText = conjugatePromptAndColorPlaceholder
+      if let selectedText = proxy.selectedText {
+        commandBar.text = conjugatePrompt + selectedText + commandCursor
+      }
 
     case "Plural":
       commandState = .plural
@@ -2302,6 +2299,9 @@ class KeyboardViewController: UIInputViewController {
       loadKeys()
       commandBar.textColor = keyCharColor
       commandBar.attributedText = pluralPromptAndColorPlaceholder
+      if let selectedText = proxy.selectedText {
+        commandBar.text = pluralPrompt + selectedText + commandCursor
+      }
 
     case "shiftFormsDisplayLeft":
       shiftLeft()

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -2267,40 +2267,65 @@ class KeyboardViewController: UIInputViewController {
       }
 
     case "Translate":
-      commandState = .translate
-      // Always start in letters with a new keyboard.
-      keyboardState = .letters
-      conditionallyHideEmojiDividers()
-      loadKeys()
-      commandBar.textColor = keyCharColor
-      commandBar.attributedText = translatePromptAndColorPlaceholder
       if let selectedText = proxy.selectedText {
-        commandBar.text = translatePrompt + selectedText + commandCursor
+        queryWordToTranslate(queriedWordToTranslate: selectedText)
+        autoActionState = .suggest
+        commandState = .idle
+        autoCapAtStartOfProxy()
+        loadKeys()
+        conditionallyDisplayAnnotation()
+      } else {
+        commandState = .translate
+        // Always start in letters with a new keyboard.
+        keyboardState = .letters
+        conditionallyHideEmojiDividers()
+        loadKeys()
+        commandBar.textColor = keyCharColor
+        commandBar.attributedText = translatePromptAndColorPlaceholder
       }
 
     case "Conjugate":
-      commandState = .conjugate
-      conditionallyHideEmojiDividers()
-      loadKeys()
-      commandBar.textColor = keyCharColor
-      commandBar.attributedText = conjugatePromptAndColorPlaceholder
       if let selectedText = proxy.selectedText {
-        commandBar.text = conjugatePrompt + selectedText + commandCursor
+        resetVerbConjugationState()
+        let conjugationTblTriggered = isVerbInConjugationTable(queriedVerbToConjugate: selectedText)
+        if conjugationTblTriggered {
+          commandState = .selectVerbConjugation
+          loadKeys() // go to conjugation view
+        } else {
+          commandState = .invalid
+          loadKeys()
+          autoCapAtStartOfProxy()
+          commandBar.text = commandPromptSpacing + invalidCommandMsg
+          commandBar.isShowingInfoButton = true
+          commandBar.textColor = keyCharColor
+        }
+      } else {
+        commandState = .conjugate
+        conditionallyHideEmojiDividers()
+        loadKeys()
+        commandBar.textColor = keyCharColor
+        commandBar.attributedText = conjugatePromptAndColorPlaceholder
       }
 
     case "Plural":
-      commandState = .plural
-      if controllerLanguage == "German" { // capitalize for nouns
-        if shiftButtonState == .normal {
-          shiftButtonState = .shift
-        }
-      }
-      conditionallyHideEmojiDividers()
-      loadKeys()
-      commandBar.textColor = keyCharColor
-      commandBar.attributedText = pluralPromptAndColorPlaceholder
       if let selectedText = proxy.selectedText {
-        commandBar.text = pluralPrompt + selectedText + commandCursor
+        queryPluralNoun(queriedNoun: selectedText)
+        autoActionState = .suggest
+        commandState = .idle
+        autoCapAtStartOfProxy()
+        loadKeys()
+        conditionallyDisplayAnnotation()
+      } else {
+        commandState = .plural
+        if controllerLanguage == "German" { // capitalize for nouns
+          if shiftButtonState == .normal {
+            shiftButtonState = .shift
+          }
+        }
+        conditionallyHideEmojiDividers()
+        loadKeys()
+        commandBar.textColor = keyCharColor
+        commandBar.attributedText = pluralPromptAndColorPlaceholder
       }
 
     case "shiftFormsDisplayLeft":

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -2751,7 +2751,7 @@ class KeyboardViewController: UIInputViewController {
         && (originalKey == spaceBar || originalKey == languageTextForSpaceBar)
         && proxy.documentContextBeforeInput?.count != 1
         && doubleSpacePeriodPossible {
-        // The fist condition prevents a period if the prior characters are spaces as the user wants a series of spaces.
+        // The first condition prevents a period if the prior characters are spaces as the user wants a series of spaces.
         if proxy.documentContextBeforeInput?.suffix(2) != "  " && ![.translate, .conjugate, .plural].contains(commandState) {
           proxy.deleteBackward()
           proxy.insertText(". ")

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Annotate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Annotate.swift
@@ -45,7 +45,7 @@ let prepAnnotationConversionDict = [
   "Russian": ["Acc": "Вин", "Dat": "Дат", "Gen": "Род", "Loc": "Мес", "Pre": "Пре", "Ins": "Инс"]
 ]
 
-/// The base function for annotation that's accessed by `selectedWordAnnotation` and `typedWordAnnotation`.
+/// The base function for annotation that's accessed by `typedWordAnnotation`.
 ///
 /// - Parameters
 ///   - wordToAnnotate: the word that an annotation should be created for.
@@ -214,22 +214,6 @@ func wordAnnotation(wordToAnnotate: String, KVC: KeyboardViewController) {
     } else {
       return
     }
-  }
-}
-
-/// Annotates a word after it's selected and the Scribe key is pressed.
-///
-/// - Parameters
-///   - KVC: the keyboard view controller.
-func selectedWordAnnotation(KVC: KeyboardViewController) {
-  wordToCheck = proxy.selectedText ?? ""
-  if !wordToCheck.isEmpty {
-    if !languagesWithCapitalizedNouns.contains(controllerLanguage) {
-      wordToCheck = wordToCheck.lowercased()
-    }
-    wordAnnotation(wordToAnnotate: wordToCheck, KVC: KVC)
-  } else {
-    return
   }
 }
 

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
@@ -66,12 +66,12 @@ func returnDeclension(keyPressed: UIButton) {
   }
 
   if !(wordPressed.contains("/") || wordPressed.contains("∗")) {
-    proxy.insertText(wordPressed + " ")
+    proxy.insertText(wordPressed + getOptionalSpace())
     deCaseVariantDeclensionState = .disabled
     autoActionState = .suggest
     commandState = .idle
   } else if controllerLanguage == "Russian" { // pronoun selection paths not implemented for Russian
-    proxy.insertText(wordPressed + " ")
+    proxy.insertText(wordPressed + getOptionalSpace())
     deCaseVariantDeclensionState = .disabled
     autoActionState = .suggest
     commandState = .idle
@@ -244,19 +244,19 @@ func returnConjugation(keyPressed: UIButton, requestedForm: String) {
         // Don't return a space as well as we have a perfect verb and the cursor will be between.
         proxy.insertText(wordToReturn.capitalize())
       } else {
-        proxy.insertText(wordToReturn.capitalized + " ")
+        proxy.insertText(wordToReturn.capitalized + getOptionalSpace())
       }
     } else {
-      proxy.insertText(wordToReturn + " ")
+      proxy.insertText(wordToReturn + getOptionalSpace())
     }
   } else if formsDisplayDimensions == .view2x2 {
     wordToReturn = LanguageDBManager.shared.queryVerb(of: verbToConjugate, with: outputCols)[0]
     potentialWordsToReturn = wordToReturn.components(separatedBy: " ")
 
     if inputWordIsCapitalized {
-      proxy.insertText(wordToReturn.capitalized + " ")
+      proxy.insertText(wordToReturn.capitalized + getOptionalSpace())
     } else {
-      proxy.insertText(wordToReturn + " ")
+      proxy.insertText(wordToReturn + getOptionalSpace())
     }
   }
 

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
@@ -204,7 +204,12 @@ func triggerVerbConjugation(commandBar: UILabel) -> Bool {
     let endIndex = commandBarText.index(commandBarText.endIndex, offsetBy: -1)
     verbToConjugate = String(commandBarText[startIndex ..< endIndex])
   }
-  verbToConjugate = String(verbToConjugate.trailingSpacesTrimmed)
+
+  return isVerbInConjugationTable(queriedVerbToConjugate: verbToConjugate)
+}
+
+func isVerbInConjugationTable(queriedVerbToConjugate: String) -> Bool {
+  verbToConjugate = String(queriedVerbToConjugate.trailingSpacesTrimmed)
 
   // Check to see if the input was uppercase to return an uppercase conjugation.
   let firstLetter = verbToConjugate.substring(toIdx: 1)

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Plural.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Plural.swift
@@ -54,12 +54,12 @@ func queryPlural(commandBar: UILabel) {
 
   if wordToReturn != "isPlural" {
     if inputWordIsCapitalized {
-      proxy.insertText(wordToReturn.capitalized + " ")
+      proxy.insertText(wordToReturn.capitalized + getOptionalSpace())
     } else {
-      proxy.insertText(wordToReturn + " ")
+      proxy.insertText(wordToReturn + getOptionalSpace())
     }
   } else {
-    proxy.insertText(noun + " ")
+    proxy.insertText(noun + getOptionalSpace())
     commandState = .alreadyPlural
   }
 }

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Plural.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Plural.swift
@@ -36,7 +36,12 @@ func queryPlural(commandBar: UILabel) {
     let endIndex = commandBarText.index(before: commandBarText.endIndex)
     noun = String(commandBarText[startIndex ..< endIndex])
   }
-  noun = String(noun.trailingSpacesTrimmed)
+
+  queryPluralNoun(queriedNoun: noun)
+}
+
+func queryPluralNoun(queriedNoun: String) {
+  var noun = String(queriedNoun.trailingSpacesTrimmed)
 
   // Check to see if the input was uppercase to return an uppercase plural.
   inputWordIsCapitalized = false

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
@@ -35,7 +35,12 @@ func queryTranslation(commandBar: UILabel) {
     let endIndex = commandBarText.index(commandBarText.endIndex, offsetBy: -1)
     wordToTranslate = String(commandBarText[startIndex ..< endIndex])
   }
-  wordToTranslate = String(wordToTranslate.trailingSpacesTrimmed)
+
+  queryWordToTranslate(queriedWordToTranslate: wordToTranslate)
+}
+
+func queryWordToTranslate(queriedWordToTranslate: String) {
+  wordToTranslate = String(queriedWordToTranslate.trailingSpacesTrimmed)
 
   // Check to see if the input was uppercase to return an uppercase conjugation.
   inputWordIsCapitalized = wordToTranslate.substring(toIdx: 1).isUppercase

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
@@ -48,8 +48,8 @@ func queryTranslation(commandBar: UILabel) {
   }
 
   if inputWordIsCapitalized {
-    proxy.insertText(wordToReturn.capitalized + " ")
+    proxy.insertText(wordToReturn.capitalized + getOptionalSpace())
   } else {
-    proxy.insertText(wordToReturn + " ")
+    proxy.insertText(wordToReturn + getOptionalSpace())
   }
 }

--- a/Keyboards/KeyboardsBase/Utilities.swift
+++ b/Keyboards/KeyboardsBase/Utilities.swift
@@ -44,3 +44,12 @@ func get_iso_code(keyboardLanguage: String) -> String {
 
   return iso
 }
+
+/// Checks if an extra space is needed in the text field when generated text is inserted
+func getOptionalSpace() -> String {
+  if proxy.documentContextAfterInput?.first == " " {
+    return ""
+  } else {
+    return " "
+  }
+}

--- a/Scribe/InstallationTab/InstallationVC.swift
+++ b/Scribe/InstallationTab/InstallationVC.swift
@@ -226,10 +226,8 @@ class InstallationVC: UIViewController {
     // Sets the font size for the text in the app screen and corresponding UIImage icons.
     if DeviceType.isPhone {
       if UIScreen.main.bounds.width > 413 || UIScreen.main.bounds.width <= 375 {
-        print(UIScreen.main.bounds.width)
         fontSize = UIScreen.main.bounds.height / 59
       } else if UIScreen.main.bounds.width <= 413 && UIScreen.main.bounds.width > 375 {
-        print(UIScreen.main.bounds.width)
         fontSize = UIScreen.main.bounds.height / 50
       }
 


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

These are changes to the behaviour of the Scribe key when text in the text field is selected. Currently, it only shows you annotations for the selected word (i.e. "N" for neuter words). Here, I changed it so the selected Scribe command's action is executed on the highlighted text.
#### Before
<img width="226" alt="Screenshot 2024-08-03 at 12 48 26" src="https://github.com/user-attachments/assets/2c61e579-40fc-478e-8128-d97c3e0cc3de">

#### After (after pressing "Plural" in the command bar)
<img width="221" alt="image" src="https://github.com/user-attachments/assets/60ab0f19-b2ae-4a1b-a89b-4bca03957312">


We also considered an option where the text would simply be entered into the command bar's text field, but decided against it:
<img width="227" alt="Screenshot 2024-08-03 at 13 04 27" src="https://github.com/user-attachments/assets/6224acba-76bc-4b0e-9136-d71142a8bc36">

### Related issues

- #141 