### PR TITLE
Enable SwiftLint orphaned_doc_comment rule and fix violation

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,7 +12,6 @@ disabled_rules:
   - type_body_length
   # WARNINGS IN PROJECT CURRENTLY
   - todo
-  - orphaned_doc_comment
   - blanket_disable_command
   - for_where
 

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -16,8 +16,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-//  Constants and functions to load the Swedish Scribe keyboard.
-//
 
 import UIKit
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

Removed orphaned_doc_comment as a disabled rule from [.swiftlint.yml](https://github.com/scribe-org/Scribe-iOS/blob/main/.swiftlint.yml) and fixed all errors for it in the codebase (there was only one violation).

After removing `orphaned_doc_comment` from `disabled_rules`, I fixed the only violation by removing an orphaned comment that was a duplicate of part of the file's header doc string. At that point, no SwiftLint warnings were shown, and running `swiftlint --strict` in the project root confirmed: `Done linting! Found 0 violations, 0 serious in 86 files.` This rule would now be enforced by SwiftLint to prevent further violations from entering the codebase.

Since only .swiftlint.yml and comments were changed, it would not affect any running code, however I verified on the iPhone 15 Pro simulator (iOS 17.5) that the app builds and runs as usual following this change!

### Related issue

- #425 
