### PR TITLE
refactor(swiftlint): enable for_where and fix violations

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,7 +13,6 @@ disabled_rules:
   # WARNINGS IN PROJECT CURRENTLY
   - todo
   - blanket_disable_command
-  - for_where
 
 identifier_name:
   min_length: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 
 # [Upcoming] Scribe-iOS 3.2.0
 
+### ♻️ Code Refactoring
+
+- All orphaned documentation comments have been removed from the codebase ([#425](https://github.com/scribe-org/Scribe-iOS/issues/425)).
+- All if clauses within for loops have been removed from the codebase ([#428](https://github.com/scribe-org/Scribe-iOS/issues/428)).
+
 # Scribe-iOS 3.1.1
 
 ### ✨ New Features

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -1920,10 +1920,8 @@ class KeyboardViewController: UIInputViewController {
       // Add UILexicon words including unpaired first and last names from Contacts to autocompletions.
       requestSupplementaryLexicon { (userLexicon: UILexicon?) in
         if let lexicon = userLexicon {
-          for item in lexicon.entries {
-            if item.documentText.count > 1 {
+          for item in lexicon.entries where item.documentText.count > 1 {
               LanguageDBManager.shared.insertAutocompleteLexion(of: item.documentText)
-            }
           }
         }
       }

--- a/Scribe/AboutTab/InformationScreenVC.swift
+++ b/Scribe/AboutTab/InformationScreenVC.swift
@@ -139,16 +139,12 @@ class InformationScreenVC: UIViewController {
 
   func setCornerImageView() {
     if DeviceType.isPhone {
-      for constraint in cornerImageView.constraints {
-        if constraint.identifier == "cornerImageView" {
+      for constraint in cornerImageView.constraints where constraint.identifier == "cornerImageView" {
           constraint.constant = 70
-        }
       }
     } else if DeviceType.isPad {
-      for constraint in cornerImageView.constraints {
-        if constraint.identifier == "cornerImageView" {
+      for constraint in cornerImageView.constraints where constraint.identifier == "cornerImageView" {
           constraint.constant = 125
-        }
       }
     }
   }

--- a/Scribe/InstallationTab/InstallationVC.swift
+++ b/Scribe/InstallationTab/InstallationVC.swift
@@ -132,18 +132,14 @@ class InstallationVC: UIViewController {
     if DeviceType.isPad {
       topIconPhone.isHidden = true
       topIconPad.isHidden = false
-      for constraint in settingsCorner.constraints {
-        if constraint.identifier == "settingsCorner" {
+      for constraint in settingsCorner.constraints where constraint.identifier == "settingsCorner" {
           constraint.constant = 125
-        }
       }
     } else {
       topIconPhone.isHidden = false
       topIconPad.isHidden = true
-      for constraint in settingsCorner.constraints {
-        if constraint.identifier == "settingsCorner" {
+      for constraint in settingsCorner.constraints where constraint.identifier == "settingsCorner" {
           constraint.constant = 70
-        }
       }
     }
   }

--- a/Scribe/SettingsTab/SettingsTableData.swift
+++ b/Scribe/SettingsTab/SettingsTableData.swift
@@ -83,11 +83,9 @@ enum SettingsTableData {
     guard let keyboards = UserDefaults.standard.dictionaryRepresentation()["AppleKeyboards"] as? [String] else { return [] }
 
     let customKeyboardExtension = appBundleIdentifier + "."
-    for keyboard in keyboards {
-      if keyboard.hasPrefix(customKeyboardExtension) {
+    for keyboard in keyboards where keyboard.hasPrefix(customKeyboardExtension) {
         let lang = keyboard.replacingOccurrences(of: customKeyboardExtension, with: "")
         installedKeyboards.append(lang.capitalized)
-      }
     }
 
     var sections = [Section]()


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Removed for_where as a disabled rule from [.swiftlint.yml](https://github.com/scribe-org/Scribe-iOS/blob/main/.swiftlint.yml) and fixed all errors for it in the codebase.

After removing `for_where` from `disabled_rules`, I fixed all 6 violations by removing the if statement within each affected for-loop, and moving the condition into a `where` clause on the for-loop itself. This is the preferred syntax for SwiftLint enforced by the `for_where` rule, and this refactor does not affect functionality. After making those changes, no SwiftLint warnings were shown, and running `swiftlint --strict` in the project root confirmed: `Done linting! Found 0 violations, 0 serious in 86 files.` This rule would now be enforced by SwiftLint to prevent further violations from entering the codebase.

I verified on the iPhone 15 Pro simulator and iPad Pro 13-inch simulator (both iOS 17.5) that the app builds and runs as usual following this change and the affected constraints look as normal. I verified with one of these fixed violations that this refactor does not affect which elements run the body of loop/conditional, using print statements and comparing the values of all the possible constraints before vs. after the refactor.

### Related issue

- #428 
