### PR TITLE
refactor(swiftlint): remove blanket_disable_command from disabled rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -12,7 +12,6 @@ disabled_rules:
   - type_body_length
   # WARNINGS IN PROJECT CURRENTLY
   - todo
-  - blanket_disable_command
 
 identifier_name:
   min_length: 1


### PR DESCRIPTION
There are no violations currently in the project. We can enable this rule moving forward to prevent future violations.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

I removed `blanket_disable_command` from `disabled_rules` in [.swiftlint.yml](https://github.com/scribe-org/Scribe-iOS/blob/main/.swiftlint.yml) and no violations were flagged. 

Running `swiftlint --strict` confirmed: `Done linting! Found 0 violations, 0 serious in 86 files.` This rule can now be enforced by SwiftLint moving forward to prevent new violations from entering the codebase. 

The only change was removing this line from from .swiftlint.yml so no functionality is affected. App builds and runs as normal on iPhone 15 Pro simulator (iOS 17.5).

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #427 
