### PR TITLE
Add an option to toggle double space period shortcuts.

### DIFF
--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -2227,7 +2227,7 @@ class KeyboardViewController: UIInputViewController {
       }
     }
   }
-  
+
   func doubleSpacePeriodsEnabled() -> Bool {
     let langCode = languagesAbbrDict[controllerLanguage] ?? "unknown"
     if let userDefaults = UserDefaults(suiteName: "group.be.scri.userDefaultsContainer") {

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -2227,6 +2227,17 @@ class KeyboardViewController: UIInputViewController {
       }
     }
   }
+  
+  func doubleSpacePeriodsEnabled() -> Bool {
+    let langCode = languagesAbbrDict[controllerLanguage] ?? "unknown"
+    if let userDefaults = UserDefaults(suiteName: "group.be.scri.userDefaultsContainer") {
+      let dictionaryKey = langCode + "DoubleSpacePeriods"
+
+      return userDefaults.bool(forKey: dictionaryKey)
+    } else {
+      return true // return the default value
+    }
+  }
 
   func emojiAutosuggestIsEnabled() -> Bool {
     let langCode = languagesAbbrDict[controllerLanguage] ?? "unknown"
@@ -2904,7 +2915,8 @@ class KeyboardViewController: UIInputViewController {
       if touch.tapCount == 2
         && (originalKey == spaceBar || originalKey == languageTextForSpaceBar)
         && proxy.documentContextBeforeInput?.count != 1
-        && doubleSpacePeriodPossible {
+        && doubleSpacePeriodPossible
+        && doubleSpacePeriodsEnabled() {
         // The first condition prevents a period if the prior characters are spaces as the user wants a series of spaces.
         if proxy.documentContextBeforeInput?.suffix(2) != "  " && ![.translate, .conjugate, .plural].contains(commandState) {
           proxy.deleteBackward()

--- a/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
+++ b/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
@@ -131,8 +131,7 @@ final class InfoChildTableViewCell: UITableViewCell {
     case .doubleSpacePeriods:
       let dictionaryKey = languageCode + "DoubleSpacePeriods"
       userDefaults.setValue(toggleSwitch.isOn, forKey: dictionaryKey)
-      break;
-      
+
     case .autosuggestEmojis:
       let dictionaryKey = languageCode + "EmojiAutosuggest"
       userDefaults.setValue(toggleSwitch.isOn, forKey: dictionaryKey)
@@ -160,7 +159,7 @@ final class InfoChildTableViewCell: UITableViewCell {
       } else {
         toggleSwitch.isOn = false  // Default value
       }
-      
+
     case .doubleSpacePeriods:
       let dictionaryKey = languageCode + "DoubleSpacePeriods"
       if let toggleValue = userDefaults.object(forKey: dictionaryKey) as? Bool {

--- a/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
+++ b/Scribe/Components/InfoChildTableViewCell/InfoChildTableViewCell.swift
@@ -128,6 +128,11 @@ final class InfoChildTableViewCell: UITableViewCell {
       let dictionaryKey = languageCode + "AccentCharacters"
       userDefaults.setValue(toggleSwitch.isOn, forKey: dictionaryKey)
 
+    case .doubleSpacePeriods:
+      let dictionaryKey = languageCode + "DoubleSpacePeriods"
+      userDefaults.setValue(toggleSwitch.isOn, forKey: dictionaryKey)
+      break;
+      
     case .autosuggestEmojis:
       let dictionaryKey = languageCode + "EmojiAutosuggest"
       userDefaults.setValue(toggleSwitch.isOn, forKey: dictionaryKey)
@@ -154,6 +159,14 @@ final class InfoChildTableViewCell: UITableViewCell {
         toggleSwitch.isOn = toggleValue
       } else {
         toggleSwitch.isOn = false  // Default value
+      }
+      
+    case .doubleSpacePeriods:
+      let dictionaryKey = languageCode + "DoubleSpacePeriods"
+      if let toggleValue = userDefaults.object(forKey: dictionaryKey) as? Bool {
+        toggleSwitch.isOn = toggleValue
+      } else {
+        toggleSwitch.isOn = true  // Default value
       }
 
     case .autosuggestEmojis:

--- a/Scribe/ParentTableCellModel.swift
+++ b/Scribe/ParentTableCellModel.swift
@@ -76,6 +76,7 @@ enum SectionState: Equatable {
 
 enum UserInteractiveState {
   case toggleCommaAndPeriod
+  case doubleSpacePeriods
   case autosuggestEmojis
   case toggleAccentCharacters
   case none

--- a/Scribe/SettingsTab/SettingsTableData.swift
+++ b/Scribe/SettingsTab/SettingsTableData.swift
@@ -65,6 +65,12 @@ enum SettingsTableData {
       headingTitle: NSLocalizedString("app.settings.functionality", value: "Functionality", comment: ""),
       section: [
         Section(
+          sectionTitle: NSLocalizedString("app.settings.functionality.doubleSpacePeriods", value: "Double space periods", comment: ""),
+          hasToggle: true,
+          sectionState: .none(.doubleSpacePeriods),
+          shortDescription: NSLocalizedString("app.settings.layout.doubleSpacePeriods.description", value: "Automatically insert a period when the space key is pressed twice.", comment: "")
+        ),
+        Section(
           sectionTitle: NSLocalizedString("app.settings.functionality.autoSuggestEmoji", value: "Autosuggest emojis", comment: ""),
           hasToggle: true,
           sectionState: .none(.autosuggestEmojis),

--- a/Scribe/i18n/Scribe-i18n/Localizable.xcstrings
+++ b/Scribe/i18n/Scribe-i18n/Localizable.xcstrings
@@ -1423,6 +1423,17 @@
         }
       }
     },
+    "app.settings.functionality.doubleSpacePeriods" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Double space periods"
+          }
+        }
+      }
+    },
     "app.settings.installedKeyboards" : {
       "comment" : "",
       "localizations" : {
@@ -1564,6 +1575,17 @@
           "stringUnit" : {
             "state" : "",
             "value" : "Ta bort tangenter med accenter på den primära tangentbordslayouten."
+          }
+        }
+      }
+    },
+    "app.settings.layout.doubleSpacePeriods.description" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Automatically insert a period when the space key is pressed twice."
           }
         }
       }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
Add an option in the Functionality section for each language keyboard, that allow user to turn off double space period shortcuts , turn on by default.

Reference Figma design [here](https://www.figma.com/design/c8945w2iyoPYVhsqW7vRn6/scribe_public_designs?node-id=513-1616&t=NJXqQ7FTAzV8nwwy-4).
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #479 
