### PR TITLE
Make the keyboard able to replace currency symbols

### DIFF
--- a/Keyboards/KeyboardBuilder.swift
+++ b/Keyboards/KeyboardBuilder.swift
@@ -1,0 +1,56 @@
+/**
+ * Building a keyboard layout using a builder pattern
+ *
+ * Copyright (C) 2024 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+protocol KeyboardBuilderProtocol {
+  func addRow(_ row: [String]) -> KeyboardBuilder
+  func build() -> [[String]]
+  func replaceKey(row: Int, column: Int, to newKey: String) -> KeyboardBuilder
+  func replaceKey(form oldKey: String, to newKey: String) -> KeyboardBuilder
+}
+
+class KeyboardBuilder: KeyboardBuilderProtocol {
+  private var rows: [[String]] = []
+
+  func addRow(_ row: [String]) -> KeyboardBuilder {
+    rows.append(row)
+    return self
+  }
+
+  func build() -> [[String]] {
+    return rows
+  }
+
+  func replaceKey(row: Int, column: Int, to newKey: String) -> KeyboardBuilder {
+    guard row < rows.count && column < rows[row].count else { return self }
+    rows[row][column] = newKey
+
+    return self
+  }
+
+  func replaceKey(form oldKey: String, to newKey: String) -> KeyboardBuilder {
+    for (rowIndex, row) in rows.enumerated() {
+        if let symbolIndex = row.firstIndex(of: oldKey) {
+            rows[rowIndex][symbolIndex] = newKey
+        }
+    }
+    return self
+  }
+}

--- a/Keyboards/KeyboardBuilder.swift
+++ b/Keyboards/KeyboardBuilder.swift
@@ -1,5 +1,5 @@
 /**
- * Building a keyboard layout using a builder pattern
+ * Building a keyboard layout using a builder pattern.
  *
  * Copyright (C) 2024 Scribe
  *

--- a/Keyboards/KeyboardProvider.swift
+++ b/Keyboards/KeyboardProvider.swift
@@ -1,0 +1,39 @@
+/**
+ * Define protocol for keyboard provider.
+ *
+ * Copyright (C) 2024 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+protocol KeyboardProviderProtocol {
+  static func genPhoneLetterKeys() -> [[String]]
+  static func genPhoneNumberKeys(currencyKey: String) -> [[String]]
+  static func genPhoneSymbolKeys(currencyKeys: [String]) -> [[String]]
+
+  static func genPadLetterKeys() -> [[String]]
+  static func genPadNumberKeys(currencyKey: String) -> [[String]]
+  static func genPadSymbolKeys(currencyKeys: [String]) -> [[String]]
+
+  static func genPadExpandedLetterKeys() -> [[String]]
+  static func genPadExpandedSymbolKeys() -> [[String]]
+}
+
+protocol KeyboardProviderDisableAccentsProtocol {
+  static func genPhoneDisableAccentsLetterKeys() -> [[String]]
+  static func genPadDisableAccentsLetterKeys() -> [[String]]
+  static func genPadExpandedDisableAccentsLetterKeys() -> [[String]]
+}

--- a/Keyboards/LanguageKeyboards/Danish/DAInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Danish/DAInterfaceVariables.swift
@@ -20,67 +20,8 @@
 import UIKit
 
 public enum DanishKeyboardConstants {
-  // iPhone keyboard layouts.
-  static let letterKeysPhone = [
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "æ", "ø"],
-    ["shift", "z", "x", "c", "v", "b", "n", "m", "delete"],
-    ["123", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let numberKeysPhone = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
-    ["-", "/", ":", ";", "(", ")", "€", "&", "@", "\""],
-    ["#+=", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let symbolKeysPhone = [
-    ["[", "]", "{", "}", "#", "%", "^", "*", "+", "="],
-    ["_", "\\", "|", "~", "<", ">", "€", "£", "¥", "·"],
-    ["123", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  // iPad keyboard layouts.
-  static let letterKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "æ", "ø", "delete"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "return"],
-    ["shift", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "undo"
-  ]
-
-  static let numberKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "`", "delete"],
-    ["@", "#", "kr", "&", "*", "(", ")", "'", "\"", "+", "·", "return"],
-    ["#+=", "%", "_", "-", "=", "/", ";", ":", ",", ".", "?", "#+="],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  static let symbolKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "'", "delete"],
-    ["€", "$", "£", "^", "[", "]", "{", "}", "―", "ᵒ", "...", "return"],
-    ["123", "§", "|", "~", "≠", "≈", "\\", "<", ">", "!", "?", "123"],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  // Expanded iPad keyboard layouts for wider devices.
-  static let letterKeysPadExpanded = [
-    ["kr", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "+", "´", "delete"],
-    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å", "@", "¨"],
-    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "æ", "ø", "'", "return"],
-    ["shift", "*", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "microphone", "scribble"
-  ]
-
-  static let symbolKeysPadExpanded = [
-    ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "—"],
-    [SpecialKeys.capsLock, "°", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"], // "undo"
-    ["shift", "…", "?", "!", "≠", "'", "\"", "_", "€", ",", ".", "-", "shift"], // "redo"
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "microphone", "scribble"
-  ]
+  static let defaultCurrencyKey = "kr"
+  static let currencyKeys = ["kr", "€", "$", "£", "¥"]
 
   // Alternate key vars.
   static let keysWithAlternates = ["a", "e", "i", "o", "u", "y", "æ", "ø", "d", "l", "n", "s"]
@@ -99,6 +40,106 @@ public enum DanishKeyboardConstants {
   static let lAlternateKeys = ["ł"]
   static let nAlternateKeys = ["ń", "ñ"]
   static let sAlternateKeys = ["ß", "ś", "š"]
+}
+
+struct DanishKeyboardProvider: KeyboardProviderProtocol {
+  // iPhone keyboard layouts.
+  static func genPhoneLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "æ", "ø"])
+      .addRow(["shift", "z", "x", "c", "v", "b", "n", "m", "delete"])
+      .addRow(["123", "selectKeyboard", "space", "return"]) // "undo"
+      .build()
+  }
+
+  static func genPhoneNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"])
+      .addRow(["-", "/", ":", ";", "(", ")", "kr", "&", "@", "\""])
+      .addRow( ["#+=", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+      .replaceKey(row: 1, column: 6, to: currencyKey)
+      .build()
+  }
+
+  static func genPhoneSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder = KeyboardBuilder()
+      .addRow(["[", "]", "{", "}", "#", "%", "^", "*", "+", "="])
+      .addRow(["_", "\\", "|", "~", "<", ">", "€", "£", "¥", "·"])
+      .addRow(["123", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 6, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 7, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 8, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // iPad keyboard layouts.
+  static func genPadLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"])
+      .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "æ", "ø", "delete"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "return"])
+      .addRow(["shift", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "undo"
+      .build()
+  }
+
+  static func genPadNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "`", "delete"])
+      .addRow(["@", "#", "kr", "&", "*", "(", ")", "'", "\"", "+", "·", "return"])
+      .addRow(["#+=", "%", "_", "-", "=", "/", ";", ":", ",", ".", "?", "#+="])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+      .replaceKey(row: 1, column: 2, to: currencyKey)
+      .build()
+  }
+
+  static func genPadSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder = KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "'", "delete"])
+      .addRow(["€", "$", "£", "^", "[", "]", "{", "}", "―", "ᵒ", "...", "return"])
+      .addRow(["123", "§", "|", "~", "≠", "≈", "\\", "<", ">", "!", "?", "123"])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 0, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 1, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 2, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // Expanded iPad keyboard layouts for wider devices.
+  static func genPadExpandedLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["kr", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "+", "´", "delete"])
+      .addRow([SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å", "@", "¨"])
+      .addRow([SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "æ", "ø", "'", "return"])
+      .addRow(["shift", "*", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+
+  static func genPadExpandedSymbolKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"])
+      .addRow([SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "—"])
+      .addRow([SpecialKeys.capsLock, "°", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "~", "return"]) // "undo"
+      .addRow(["shift", "…", "?", "!", "≠", "'", "\"", "_", "€", ",", ".", "-", "shift"]) // "redo"
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
 }
 
 /// Gets the keys for the Danish keyboard.

--- a/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
@@ -71,7 +71,6 @@ struct EnglishKeyboardProvider: KeyboardProviderProtocol {
     if currencyKeys.count < 3 {
       return keyboardBuilder.build()
     } else {
-      // Replace currencies
       return keyboardBuilder
         .replaceKey(row: 1, column: 6, to: currencyKeys[0])
         .replaceKey(row: 1, column: 7, to: currencyKeys[1])
@@ -111,7 +110,6 @@ struct EnglishKeyboardProvider: KeyboardProviderProtocol {
     if currencyKeys.count < 3 {
       return keyboardBuilder.build()
     } else {
-      // Replace currencies
       return keyboardBuilder
         .replaceKey(row: 1, column: 0, to: currencyKeys[0])
         .replaceKey(row: 1, column: 1, to: currencyKeys[1])

--- a/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
@@ -20,67 +20,8 @@
 import UIKit
 
 public enum EnglishKeyboardConstants {
-  // iPhone keyboard layouts.
-  static let letterKeysPhone = [
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l"],
-    ["shift", "z", "x", "c", "v", "b", "n", "m", "delete"],
-    ["123", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let numberKeysPhone = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
-    ["-", "/", ":", ";", "(", ")", "$", "&", "@", "\""],
-    ["#+=", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let symbolKeysPhone = [
-    ["[", "]", "{", "}", "#", "%", "^", "*", "+", "="],
-    ["_", "\\", "|", "~", "<", ">", "€", "£", "¥", "·"],
-    ["123", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  // iPad keyboard layouts.
-  static let letterKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"],
-    ["shift", "w", "x", "c", "v", "b", "n", "m", ",", ".", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "undo"
-  ]
-
-  static let numberKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"],
-    ["@", "#", "$", "&", "*", "(", ")", "'", "\"", "return"],
-    ["#+=", "%", "_", "+", "=", "/", ";", ":", ",", ".", "#+="],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  static let symbolKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"],
-    ["€", "£", "¥", "_", "^", "[", "]", "{", "}", "return"],
-    ["123", "§", "|", "~", "...", "\\", "<", ">", "!", "?", "123"],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  // Expanded iPad keyboard layouts for wider devices.
-  static let letterKeysPadExpanded = [
-    ["~", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "delete"],
-    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]", "\\"],
-    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", ":", ";", "'", "return"],
-    ["shift", "-", "z", "x", "c", "v", "b", "n", "m", ",", ".", "/", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "microphone", "scribble"
-  ]
-
-  static let symbolKeysPadExpanded = [
-    ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "—", "~", "°"],
-    [SpecialKeys.capsLock, "-", "\\", ":", ";", "(", ")", "&", "@", "$", "£", "¥", "€", "return"], // "undo"
-    ["shift", "…", "?", "!", "≠", "'", "\"", "|", "_", ".", ",", "/", "shift"], // "redo"
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "microphone", "scribble"
-  ]
+  static let defaultCurrencyKey = "$"
+  static let currencyKeys = ["$", "€", "£", "¥"]
 
   // Alternate key vars.
   static let keysWithAlternates = ["a", "e", "i", "o", "u", "y", "c", "l", "n", "s", "z"]
@@ -99,12 +40,118 @@ public enum EnglishKeyboardConstants {
   static let zAlternateKeys = ["ž", "ź", "ż"]
 }
 
+// MARK: iPhone keyboard layouts.
+func genPhoneLetterKeys() -> [[String]] {
+  return KeyboardBuilder()
+    .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"])
+    .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l"])
+    .addRow(["shift", "z", "x", "c", "v", "b", "n", "m", "delete"])
+    .addRow(["123", "selectKeyboard", "space", "return"]) // "undo"
+    .build()
+}
+
+func genPhoneNumberKeys(currencyKey: String) -> [[String]] {
+  return KeyboardBuilder()
+    .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"])
+    .addRow(["-", "/", ":", ";", "(", ")", "$", "&", "@", "\""])
+    .addRow(["#+=", ".", ",", "?", "!", "'", "delete"])
+    .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+    .replaceKey(row: 1, column: 6, to: currencyKey)
+    .build()
+}
+
+func genPhoneSymbolKeys(currencyKeys: [String]) -> [[String]] {
+  let keyboardBuilder = KeyboardBuilder()
+    .addRow(["[", "]", "{", "}", "#", "%", "^", "*", "+", "="])
+    .addRow(["_", "\\", "|", "~", "<", ">", "€", "£", "¥", "·"])
+    .addRow(["123", ".", ",", "?", "!", "'", "delete"])
+    .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+
+  if currencyKeys.count < 3 {
+    return keyboardBuilder.build()
+  } else {
+    // Replace currencies
+    return keyboardBuilder
+      .replaceKey(row: 1, column: 6, to: currencyKeys[0])
+      .replaceKey(row: 1, column: 7, to: currencyKeys[1])
+      .replaceKey(row: 1, column: 8, to: currencyKeys[2])
+      .build()
+  }
+}
+
+// MARK: iPad keyboard layouts.
+func genPadLetterKeys() -> [[String]] {
+  return KeyboardBuilder()
+    .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"])
+    .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"])
+    .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"])
+    .addRow(["shift", "w", "x", "c", "v", "b", "n", "m", ",", ".", "shift"])
+    .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "undo"
+    .build()
+}
+
+func genPadNumberKeys() -> [[String]] {
+  return KeyboardBuilder()
+    .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"])
+    .addRow(["@", "#", "$", "&", "*", "(", ")", "'", "\"", "return"])
+    .addRow(["#+=", "%", "_", "+", "=", "/", ";", ":", ",", ".", "#+="])
+    .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+    .build()
+}
+
+func genPadSymbolKeys() -> [[String]] {
+  return KeyboardBuilder()
+    .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"])
+    .addRow(["€", "£", "¥", "_", "^", "[", "]", "{", "}", "return"])
+    .addRow(["123", "§", "|", "~", "...", "\\", "<", ">", "!", "?", "123"])
+    .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+    .build()
+}
+
+func genPadExpandedLetterKeys() -> [[String]] {
+  return KeyboardBuilder()
+    .addRow(["~", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "delete"])
+    .addRow([SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]", "\\"])
+    .addRow([SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", ":", ";", "'", "return"])
+    .addRow(["shift", "-", "z", "x", "c", "v", "b", "n", "m", ",", ".", "/", "shift"])
+    .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "microphone", "scribble"
+    .build()
+}
+
+func genPadExpandedSymbolKeys() -> [[String]] {
+  return KeyboardBuilder()
+    .addRow(["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"])
+    .addRow([SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "—", "~", "°"])
+    .addRow([SpecialKeys.capsLock, "-", "\\", ":", ";", "(", ")", "&", "@", "$", "£", "¥", "€", "return"]) // "undo"
+    .addRow(["shift", "…", "?", "!", "≠", "'", "\"", "|", "_", ".", ",", "/", "shift"]) // "redo"
+    .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "microphone", "scribble"
+    .build()
+}
+
+// MARK: Generate and set keyboard
+
 /// Gets the keys for the English keyboard.
 func getENKeys() {
   if DeviceType.isPhone {
-    letterKeys = EnglishKeyboardConstants.letterKeysPhone
-    numberKeys = EnglishKeyboardConstants.numberKeysPhone
-    symbolKeys = EnglishKeyboardConstants.symbolKeysPhone
+    guard let userDefaults = UserDefaults(suiteName: "group.be.scri.userDefaultsContainer") else {
+      fatalError()
+    }
+
+    var currencyKeys = EnglishKeyboardConstants.currencyKeys
+    var currencyKey = EnglishKeyboardConstants.defaultCurrencyKey
+    let dictionaryKey = controllerLanguage + "defaultCurrencySymbol"
+    if let currencyValue = userDefaults.string(forKey: dictionaryKey) {
+      currencyKey = currencyValue
+    } else {
+      userDefaults.setValue(currencyKey, forKey: dictionaryKey)
+    }
+    if let index = currencyKeys.firstIndex(of: currencyKey) {
+      currencyKeys.remove(at: index)
+    }
+
+    letterKeys = genPhoneLetterKeys()
+    numberKeys = genPhoneNumberKeys(currencyKey: currencyKey)
+    symbolKeys = genPhoneSymbolKeys(currencyKeys: currencyKeys)
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "1", "-", "[", "_"]
@@ -113,14 +160,14 @@ func getENKeys() {
   } else {
     // Use the expanded keys layout if the iPad is wide enough and has no home button.
     if usingExpandedKeyboard {
-      letterKeys = EnglishKeyboardConstants.letterKeysPadExpanded
-      symbolKeys = EnglishKeyboardConstants.symbolKeysPadExpanded
+      letterKeys = genPadExpandedLetterKeys()
+      symbolKeys = genPadExpandedSymbolKeys()
 
       allKeys = Array(letterKeys.joined()) + Array(symbolKeys.joined())
     } else {
-      letterKeys = EnglishKeyboardConstants.letterKeysPad
-      numberKeys = EnglishKeyboardConstants.numberKeysPad
-      symbolKeys = EnglishKeyboardConstants.symbolKeysPad
+      letterKeys = genPadLetterKeys()
+      numberKeys = genPadNumberKeys()
+      symbolKeys = genPadSymbolKeys()
 
       letterKeys.removeFirst(1)
 

--- a/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
@@ -40,103 +40,105 @@ public enum EnglishKeyboardConstants {
   static let zAlternateKeys = ["ž", "ź", "ż"]
 }
 
-// MARK: iPhone keyboard layouts.
-func genPhoneLetterKeys() -> [[String]] {
-  return KeyboardBuilder()
-    .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"])
-    .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l"])
-    .addRow(["shift", "z", "x", "c", "v", "b", "n", "m", "delete"])
-    .addRow(["123", "selectKeyboard", "space", "return"]) // "undo"
-    .build()
-}
-
-func genPhoneNumberKeys(currencyKey: String) -> [[String]] {
-  return KeyboardBuilder()
-    .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"])
-    .addRow(["-", "/", ":", ";", "(", ")", "$", "&", "@", "\""])
-    .addRow(["#+=", ".", ",", "?", "!", "'", "delete"])
-    .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
-    .replaceKey(row: 1, column: 6, to: currencyKey)
-    .build()
-}
-
-func genPhoneSymbolKeys(currencyKeys: [String]) -> [[String]] {
-  let keyboardBuilder = KeyboardBuilder()
-    .addRow(["[", "]", "{", "}", "#", "%", "^", "*", "+", "="])
-    .addRow(["_", "\\", "|", "~", "<", ">", "€", "£", "¥", "·"])
-    .addRow(["123", ".", ",", "?", "!", "'", "delete"])
-    .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
-
-  if currencyKeys.count < 3 {
-    return keyboardBuilder.build()
-  } else {
-    // Replace currencies
-    return keyboardBuilder
-      .replaceKey(row: 1, column: 6, to: currencyKeys[0])
-      .replaceKey(row: 1, column: 7, to: currencyKeys[1])
-      .replaceKey(row: 1, column: 8, to: currencyKeys[2])
+struct EnglishKeyboardProvider: KeyboardProviderProtocol {
+  // iPhone keyboard layouts.
+  static func genPhoneLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l"])
+      .addRow(["shift", "z", "x", "c", "v", "b", "n", "m", "delete"])
+      .addRow(["123", "selectKeyboard", "space", "return"]) // "undo"
       .build()
   }
-}
 
-// MARK: iPad keyboard layouts.
-func genPadLetterKeys() -> [[String]] {
-  return KeyboardBuilder()
-    .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"])
-    .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"])
-    .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"])
-    .addRow(["shift", "w", "x", "c", "v", "b", "n", "m", ",", ".", "shift"])
-    .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "undo"
-    .build()
-}
-
-func genPadNumberKeys(currencyKey: String) -> [[String]] {
-  return KeyboardBuilder()
-    .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"])
-    .addRow(["@", "#", "$", "&", "*", "(", ")", "'", "\"", "return"])
-    .addRow(["#+=", "%", "_", "+", "=", "/", ";", ":", ",", ".", "#+="])
-    .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
-    .replaceKey(row: 1, column: 2, to: currencyKey)
-    .build()
-}
-
-func genPadSymbolKeys(currencyKeys: [String]) -> [[String]] {
-  let keyboardBuilder = KeyboardBuilder()
-    .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"])
-    .addRow(["€", "£", "¥", "_", "^", "[", "]", "{", "}", "return"])
-    .addRow(["123", "§", "|", "~", "...", "\\", "<", ">", "!", "?", "123"])
-    .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
-
-  if currencyKeys.count < 3 {
-    return keyboardBuilder.build()
-  } else {
-    // Replace currencies
-    return keyboardBuilder
-      .replaceKey(row: 1, column: 0, to: currencyKeys[0])
-      .replaceKey(row: 1, column: 1, to: currencyKeys[1])
-      .replaceKey(row: 1, column: 2, to: currencyKeys[2])
+  static func genPhoneNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"])
+      .addRow(["-", "/", ":", ";", "(", ")", "$", "&", "@", "\""])
+      .addRow(["#+=", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+      .replaceKey(row: 1, column: 6, to: currencyKey)
       .build()
   }
-}
 
-func genPadExpandedLetterKeys() -> [[String]] {
-  return KeyboardBuilder()
-    .addRow(["~", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "delete"])
-    .addRow([SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]", "\\"])
-    .addRow([SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", ":", ";", "'", "return"])
-    .addRow(["shift", "-", "z", "x", "c", "v", "b", "n", "m", ",", ".", "/", "shift"])
-    .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "microphone", "scribble"
-    .build()
-}
+  static func genPhoneSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder = KeyboardBuilder()
+      .addRow(["[", "]", "{", "}", "#", "%", "^", "*", "+", "="])
+      .addRow(["_", "\\", "|", "~", "<", ">", "€", "£", "¥", "·"])
+      .addRow(["123", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
 
-func genPadExpandedSymbolKeys() -> [[String]] {
-  return KeyboardBuilder()
-    .addRow(["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"])
-    .addRow([SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "—", "~", "°"])
-    .addRow([SpecialKeys.capsLock, "-", "\\", ":", ";", "(", ")", "&", "@", "$", "£", "¥", "€", "return"]) // "undo"
-    .addRow(["shift", "…", "?", "!", "≠", "'", "\"", "|", "_", ".", ",", "/", "shift"]) // "redo"
-    .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "microphone", "scribble"
-    .build()
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      // Replace currencies
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 6, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 7, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 8, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // iPad keyboard layouts.
+  static func genPadLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"])
+      .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"])
+      .addRow(["shift", "w", "x", "c", "v", "b", "n", "m", ",", ".", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "undo"
+      .build()
+  }
+
+  static func genPadNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"])
+      .addRow(["@", "#", "$", "&", "*", "(", ")", "'", "\"", "return"])
+      .addRow(["#+=", "%", "_", "+", "=", "/", ";", ":", ",", ".", "#+="])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+      .replaceKey(row: 1, column: 2, to: currencyKey)
+      .build()
+  }
+
+  static func genPadSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder = KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"])
+      .addRow(["€", "£", "¥", "_", "^", "[", "]", "{", "}", "return"])
+      .addRow(["123", "§", "|", "~", "...", "\\", "<", ">", "!", "?", "123"])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      // Replace currencies
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 0, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 1, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 2, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  static func genPadExpandedLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["~", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "delete"])
+      .addRow([SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]", "\\"])
+      .addRow([SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", ":", ";", "'", "return"])
+      .addRow(["shift", "-", "z", "x", "c", "v", "b", "n", "m", ",", ".", "/", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+
+  static func genPadExpandedSymbolKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"])
+      .addRow([SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "—", "~", "°"])
+      .addRow([SpecialKeys.capsLock, "-", "\\", ":", ";", "(", ")", "&", "@", "$", "£", "¥", "€", "return"]) // "undo"
+      .addRow(["shift", "…", "?", "!", "≠", "'", "\"", "|", "_", ".", ",", "/", "shift"]) // "redo"
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
 }
 
 // MARK: Generate and set keyboard
@@ -160,9 +162,9 @@ func getENKeys() {
   }
 
   if DeviceType.isPhone {
-    letterKeys = genPhoneLetterKeys()
-    numberKeys = genPhoneNumberKeys(currencyKey: currencyKey)
-    symbolKeys = genPhoneSymbolKeys(currencyKeys: currencyKeys)
+    letterKeys = EnglishKeyboardProvider.genPhoneLetterKeys()
+    numberKeys = EnglishKeyboardProvider.genPhoneNumberKeys(currencyKey: currencyKey)
+    symbolKeys = EnglishKeyboardProvider.genPhoneSymbolKeys(currencyKeys: currencyKeys)
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "1", "-", "[", "_"]
@@ -171,14 +173,14 @@ func getENKeys() {
   } else {
     // Use the expanded keys layout if the iPad is wide enough and has no home button.
     if usingExpandedKeyboard {
-      letterKeys = genPadExpandedLetterKeys()
-      symbolKeys = genPadExpandedSymbolKeys()
+      letterKeys = EnglishKeyboardProvider.genPadExpandedLetterKeys()
+      symbolKeys = EnglishKeyboardProvider.genPadExpandedSymbolKeys()
 
       allKeys = Array(letterKeys.joined()) + Array(symbolKeys.joined())
     } else {
-      letterKeys = genPadLetterKeys()
-      numberKeys = genPadNumberKeys(currencyKey: currencyKey)
-      symbolKeys = genPadSymbolKeys(currencyKeys: currencyKeys)
+      letterKeys = EnglishKeyboardProvider.genPadLetterKeys()
+      numberKeys = EnglishKeyboardProvider.genPadNumberKeys(currencyKey: currencyKey)
+      symbolKeys = EnglishKeyboardProvider.genPadSymbolKeys(currencyKeys: currencyKeys)
 
       letterKeys.removeFirst(1)
 

--- a/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
@@ -69,7 +69,6 @@ struct FrenchKeyboardProvider: KeyboardProviderProtocol {
     if currencyKeys.count < 3 {
       return keyboardBuilder.build()
     } else {
-      // Replace currencies
       return keyboardBuilder
         .replaceKey(row: 1, column: 6, to: currencyKeys[0])
         .replaceKey(row: 1, column: 7, to: currencyKeys[1])
@@ -109,7 +108,6 @@ struct FrenchKeyboardProvider: KeyboardProviderProtocol {
     if currencyKeys.count < 3 {
       return keyboardBuilder.build()
     } else {
-      // Replace currencies
       return keyboardBuilder
         .replaceKey(row: 1, column: 7, to: currencyKeys[0])
         .replaceKey(row: 1, column: 8, to: currencyKeys[1])
@@ -138,7 +136,6 @@ struct FrenchKeyboardProvider: KeyboardProviderProtocol {
       .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "microphone", "scribble"
       .build()
   }
-
 }
 
 /// Gets the keys for the French keyboard.

--- a/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
@@ -20,67 +20,8 @@
 import UIKit
 
 public enum FrenchKeyboardConstants {
-  // iPhone keyboard layouts.
-  static let letterKeysPhone = [
-    ["a", "z", "e", "r", "t", "y", "u", "i", "o", "p"],
-    ["q", "s", "d", "f", "g", "h", "j", "k", "l", "m"],
-    ["shift", "w", "x", "c", "v", "b", "n", "´", "delete"],
-    ["123", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let numberKeysPhone = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
-    ["-", "/", ":", ";", "(", ")", "€", "&", "@", "\""],
-    ["#+=", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let symbolKeysPhone = [
-    ["[", "]", "{", "}", "#", "%", "^", "*", "+", "="],
-    ["_", "\\", "|", "~", "<", ">", "$", "£", "¥", "·"],
-    ["123", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  // iPad keyboard layouts.
-  static let letterKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
-    ["a", "z", "e", "r", "t", "y", "u", "i", "o", "p", "delete"],
-    ["q", "s", "d", "f", "g", "h", "j", "k", "l", "m", "return"],
-    ["shift", "w", "x", "c", "v", "b", "n", "´", ",", ".", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "undo"
-  ]
-
-  static let numberKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"],
-    ["@", "#", "&", "\"", "€", "(", "!", ")", "-", "*", "return"],
-    ["#+=", "%", "_", "+", "=", "/", ";", ":", ",", ".", "#+="],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  static let symbolKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"],
-    ["~", "ᵒ", "[", "]", "{", "}", "^", "$", "£", "¥", "return"],
-    ["123", "§", "<", ">", "|", "\\", "...", "·", "?", "'", "123"],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  // Expanded iPad keyboard layouts for wider devices.
-  static let letterKeysPadExpanded = [
-    ["@", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "ç", "à", "delete"],
-    [SpecialKeys.indent, "a", "z", "e", "r", "t", "y", "u", "i", "o", "p", "^", "+", "*"],
-    [SpecialKeys.capsLock, "q", "s", "d", "f", "g", "h", "j", "k", "l", "m", "ù", "#", "return"],
-    ["shift", "/", "w", "x", "c", "v", "b", "n", ":", "-", ",", ".", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "microphone", "scribble"
-  ]
-
-  static let symbolKeysPadExpanded = [
-    ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    [SpecialKeys.indent, "\"", "|", "§", "[", "]", "{", "}", "-", "%", "=", "^", "+", "*"],
-    [SpecialKeys.capsLock, "/", "…", "_", "(", ")", "&", "$", "£", "¥", "€", "@", "#", "return"], // "undo"
-    ["shift", "'", "?", "!", "~", "≠", "°", ";", ":", "-", ",", ".", "shift"], // "redo"
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "microphone", "scribble"
-  ]
+  static let defaultCurrencyKey = "€"
+  static let currencyKeys = ["€", "$", "£", "¥"]
 
   // Alternate key vars.
   static let keysWithAlternates = ["a", "e", "i", "o", "u", "y", "c", "n"]
@@ -97,12 +38,131 @@ public enum FrenchKeyboardConstants {
   static let nAlternateKeys = ["ń", "ñ"]
 }
 
+struct FrenchKeyboardProvider: KeyboardProviderProtocol {
+  // iPhone keyboard layouts.
+  static func genPhoneLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["a", "z", "e", "r", "t", "y", "u", "i", "o", "p"])
+      .addRow(["q", "s", "d", "f", "g", "h", "j", "k", "l", "m"])
+      .addRow(["shift", "w", "x", "c", "v", "b", "n", "´", "delete"])
+      .addRow(["123", "selectKeyboard", "space", "return"]) // "undo"
+      .build()
+  }
+
+  static func genPhoneNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"])
+      .addRow(["-", "/", ":", ";", "(", ")", "€", "&", "@", "\""])
+      .addRow(["#+=", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+      .replaceKey(row: 1, column: 6, to: currencyKey)
+      .build()
+  }
+
+  static func genPhoneSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder = KeyboardBuilder()
+      .addRow(["[", "]", "{", "}", "#", "%", "^", "*", "+", "="])
+      .addRow(["_", "\\", "|", "~", "<", ">", "$", "£", "¥", "·"])
+      .addRow(["123", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      // Replace currencies
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 6, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 7, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 8, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // iPad keyboard layouts.
+  static func genPadLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"])
+      .addRow(["a", "z", "e", "r", "t", "y", "u", "i", "o", "p", "delete"])
+      .addRow(["q", "s", "d", "f", "g", "h", "j", "k", "l", "m", "return"])
+      .addRow(["shift", "w", "x", "c", "v", "b", "n", "´", ",", ".", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "undo"
+      .build()
+  }
+
+  static func genPadNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"])
+      .addRow(["@", "#", "&", "\"", "€", "(", "!", ")", "-", "*", "return"])
+      .addRow(["#+=", "%", "_", "+", "=", "/", ";", ":", ",", ".", "#+="])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+      .replaceKey(row: 1, column: 4, to: currencyKey)
+      .build()
+  }
+
+  static func genPadSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder = KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"])
+      .addRow(["~", "ᵒ", "[", "]", "{", "}", "^", "$", "£", "¥", "return"])
+      .addRow(["123", "§", "<", ">", "|", "\\", "...", "·", "?", "'", "123"])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      // Replace currencies
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 7, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 8, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 9, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // Expanded iPad keyboard layouts for wider devices.
+  static func genPadExpandedLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["@", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "ç", "à", "delete"])
+      .addRow([SpecialKeys.indent, "a", "z", "e", "r", "t", "y", "u", "i", "o", "p", "^", "+", "*"])
+      .addRow([SpecialKeys.capsLock, "q", "s", "d", "f", "g", "h", "j", "k", "l", "m", "ù", "#", "return"])
+      .addRow(["shift", "/", "w", "x", "c", "v", "b", "n", ":", "-", ",", ".", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+
+  static func genPadExpandedSymbolKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"])
+      .addRow([SpecialKeys.indent, "\"", "|", "§", "[", "]", "{", "}", "-", "%", "=", "^", "+", "*"])
+      .addRow([SpecialKeys.capsLock, "/", "…", "_", "(", ")", "&", "$", "£", "¥", "€", "@", "#", "return"]) // "undo"
+      .addRow(["shift", "'", "?", "!", "~", "≠", "°", ";", ":", "-", ",", ".", "shift"]) // "redo"
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+
+}
+
 /// Gets the keys for the French keyboard.
 func getFRKeys() {
+  guard let userDefaults = UserDefaults(suiteName: "group.be.scri.userDefaultsContainer") else {
+    fatalError()
+  }
+
+  var currencyKey = FrenchKeyboardConstants.defaultCurrencyKey
+  var currencyKeys = FrenchKeyboardConstants.currencyKeys
+  let dictionaryKey = controllerLanguage + "defaultCurrencySymbol"
+  if let currencyValue = userDefaults.string(forKey: dictionaryKey) {
+    currencyKey = currencyValue
+  } else {
+    userDefaults.setValue(currencyKey, forKey: dictionaryKey)
+  }
+  if let index = currencyKeys.firstIndex(of: currencyKey) {
+    currencyKeys.remove(at: index)
+  }
+
   if DeviceType.isPhone {
-    letterKeys = FrenchKeyboardConstants.letterKeysPhone
-    numberKeys = FrenchKeyboardConstants.numberKeysPhone
-    symbolKeys = FrenchKeyboardConstants.symbolKeysPhone
+    letterKeys = FrenchKeyboardProvider.genPhoneLetterKeys()
+    numberKeys = FrenchKeyboardProvider.genPhoneNumberKeys(currencyKey: currencyKey)
+    symbolKeys = FrenchKeyboardProvider.genPhoneSymbolKeys(currencyKeys: currencyKeys)
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["a", "q", "1", "-", "[", "_"]
@@ -111,14 +171,14 @@ func getFRKeys() {
   } else {
     // Use the expanded keys layout if the iPad is wide enough and has no home button.
     if usingExpandedKeyboard {
-      letterKeys = FrenchKeyboardConstants.letterKeysPadExpanded
-      symbolKeys = FrenchKeyboardConstants.symbolKeysPadExpanded
+      letterKeys = FrenchKeyboardProvider.genPadExpandedLetterKeys()
+      symbolKeys = FrenchKeyboardProvider.genPadExpandedSymbolKeys()
 
       allKeys = Array(letterKeys.joined()) + Array(symbolKeys.joined())
     } else {
-      letterKeys = FrenchKeyboardConstants.letterKeysPad
-      numberKeys = FrenchKeyboardConstants.numberKeysPad
-      symbolKeys = FrenchKeyboardConstants.symbolKeysPad
+      letterKeys = FrenchKeyboardProvider.genPadLetterKeys()
+      numberKeys = FrenchKeyboardProvider.genPadNumberKeys(currencyKey: currencyKey)
+      symbolKeys = FrenchKeyboardProvider.genPadSymbolKeys(currencyKeys: currencyKeys)
 
       letterKeys.removeFirst(1)
 

--- a/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
@@ -20,90 +20,8 @@
 import UIKit
 
 public enum GermanKeyboardConstants {
-  // iPhone keyboard layouts.
-  static let letterKeysPhone = [
-    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "ü"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä"],
-    ["shift", "y", "x", "c", "v", "b", "n", "m", "delete"],
-    ["123", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let letterKeysPhoneDisableAccents = [
-    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l"],
-    ["shift", "y", "x", "c", "v", "b", "n", "m", "delete"],
-    ["123", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let numberKeysPhone = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
-    ["-", "/", ":", ";", "(", ")", "€", "&", "@", "\""],
-    ["#+=", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let symbolKeysPhone = [
-    ["[", "]", "{", "}", "#", "%", "^", "*", "+", "="],
-    ["_", "\\", "|", "~", "<", ">", "$", "£", "¥", "·"],
-    ["123", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  // iPad keyboard layouts.
-  static let letterKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
-    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "ü", "delete"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "return"],
-    ["shift", "y", "x", "c", "v", "b", "n", "m", ",", ".", "ß", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "undo"
-  ]
-
-  static let letterKeysPadDisableAccents = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
-    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "delete"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"],
-    ["shift", "y", "x", "c", "v", "b", "n", "m", ",", ".", "ß", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "undo"
-  ]
-
-  static let numberKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "+", "delete"],
-    ["\"", "§", "€", "%", "&", "/", "(", ")", "=", "'", "#", "return"],
-    ["#+=", "—", "`", "'", "...", "@", ";", ":", ",", ".", "-", "#+="],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  static let symbolKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "*", "delete"],
-    ["$", "£", "¥", "¿", "―", "\\", "[", "]", "{", "}", "|", "return"],
-    ["123", "¡", "<", ">", "≠", "·", "^", "~", "!", "?", "_", "123"],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  // Expanded iPad keyboard layouts for wider devices.
-  static let letterKeysPadExpanded = [
-    ["^", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "ß", "´", "delete"],
-    [SpecialKeys.indent, "q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "ü", "+", "*"],
-    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "#", "return"],
-    ["shift", "'", "y", "x", "c", "v", "b", "n", "m", "-", ",", ".", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "microphone", "scribble"
-  ]
-
-  static let letterKeysPadExpandedDisableAccents = [
-    ["^", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "ß", "´", "delete"],
-    [SpecialKeys.indent, "q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "=", "+", "*"],
-    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "/", "@", "#", "return"],
-    ["shift", "'", "y", "x", "c", "v", "b", "n", "m", "-", ",", ".", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "microphone", "scribble"
-  ]
-
-  static let symbolKeysPadExpanded = [
-    ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    [SpecialKeys.indent, "\"", "|", "§", "[", "]", "{", "}", "—", "%", "^", "=", "+", "*"],
-    [SpecialKeys.capsLock, ":", ";", "(", ")", "&", "$", "£", "¥", "€", "/", "@", "#", "return"], // "undo"
-    ["shift", "'", "?", "!", "~", "≠", "°", "…", "_", "-", ",", ".", "shift"], // "redo"
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "microphone", "scribble"
-  ]
+  static let defaultCurrencyKey = "€"
+  static let currencyKeys = ["€", "$", "£", "¥"]
 
   // Alternate key vars.
   static let keysWithAlternates = ["a", "e", "i", "o", "u", "y", "c", "l", "n", "s", "z"]
@@ -126,18 +44,163 @@ public enum GermanKeyboardConstants {
   static let zAlternateKeys = ["ź", "ż"]
 }
 
+struct GermanKeyboardProvider: KeyboardProviderProtocol, KeyboardProviderDisableAccentsProtocol {
+  // iPhone keyboard layouts.
+  static func genPhoneLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "ü"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä"])
+      .addRow(["shift", "y", "x", "c", "v", "b", "n", "m", "delete"])
+      .addRow(["123", "selectKeyboard", "space", "return"]) // "undo"
+      .build()
+  }
+
+  static func genPhoneDisableAccentsLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["q", "w", "e", "r", "t", "z", "u", "i", "o", "p"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l"])
+      .addRow(["shift", "y", "x", "c", "v", "b", "n", "m", "delete"])
+      .addRow(["123", "selectKeyboard", "space", "return"]) // "undo"
+      .build()
+  }
+
+  static func genPhoneNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"])
+      .addRow(["-", "/", ":", ";", "(", ")", "€", "&", "@", "\""])
+      .addRow(["#+=", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+      .replaceKey(row: 1, column: 6, to: currencyKey)
+      .build()
+  }
+
+  static func genPhoneSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder = KeyboardBuilder()
+      .addRow(["[", "]", "{", "}", "#", "%", "^", "*", "+", "="])
+      .addRow(["_", "\\", "|", "~", "<", ">", "$", "£", "¥", "·"])
+      .addRow(["123", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      // Replace currencies
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 6, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 7, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 8, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // iPad keyboard layouts.
+  static func genPadLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"])
+      .addRow(["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "ü", "delete"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "return"])
+      .addRow(["shift", "y", "x", "c", "v", "b", "n", "m", ",", ".", "ß", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "undo"
+      .build()
+  }
+
+  static func genPadDisableAccentsLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"])
+      .addRow(["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "delete"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"])
+      .addRow(["shift", "y", "x", "c", "v", "b", "n", "m", ",", ".", "ß", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "undo"
+      .build()
+  }
+
+  static func genPadNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "+", "delete"])
+      .addRow(["\"", "§", "€", "%", "&", "/", "(", ")", "=", "'", "#", "return"])
+      .addRow(["#+=", "—", "`", "'", "...", "@", ";", ":", ",", ".", "-", "#+="])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+      .replaceKey(row: 1, column: 2, to: currencyKey)
+      .build()
+  }
+
+  static func genPadSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder = KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "*", "delete"])
+      .addRow(["$", "£", "¥", "¿", "―", "\\", "[", "]", "{", "}", "|", "return"])
+      .addRow(["123", "¡", "<", ">", "≠", "·", "^", "~", "!", "?", "_", "123"])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      // Replace currencies
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 0, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 1, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 2, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // Expanded iPad keyboard layouts for wider devices.
+  static func genPadExpandedLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["^", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "ß", "´", "delete"])
+      .addRow([SpecialKeys.indent, "q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "ü", "+", "*"])
+      .addRow([SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "#", "return"])
+      .addRow(["shift", "'", "y", "x", "c", "v", "b", "n", "m", "-", ",", ".", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+
+  static func genPadExpandedDisableAccentsLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["^", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "ß", "´", "delete"])
+      .addRow([SpecialKeys.indent, "q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "=", "+", "*"])
+      .addRow([SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "/", "@", "#", "return"])
+      .addRow(["shift", "'", "y", "x", "c", "v", "b", "n", "m", "-", ",", ".", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+
+  static func genPadExpandedSymbolKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"])
+      .addRow([SpecialKeys.indent, "\"", "|", "§", "[", "]", "{", "}", "—", "%", "^", "=", "+", "*"])
+      .addRow([SpecialKeys.capsLock, ":", ";", "(", ")", "&", "$", "£", "¥", "€", "/", "@", "#", "return"]) // "undo"
+      .addRow(["shift", "'", "?", "!", "~", "≠", "°", "…", "_", "-", ",", ".", "shift"]) // "redo"
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+}
+
 /// Gets the keys for the German keyboard.
 func getDEKeys() {
-  let userDefaults = UserDefaults(suiteName: "group.be.scri.userDefaultsContainer")!
+  guard let userDefaults = UserDefaults(suiteName: "group.be.scri.userDefaultsContainer") else {
+    fatalError()
+  }
+
+  var currencyKey = GermanKeyboardConstants.defaultCurrencyKey
+  var currencyKeys = GermanKeyboardConstants.currencyKeys
+  let dictionaryKey = controllerLanguage + "defaultCurrencySymbol"
+  if let currencyValue = userDefaults.string(forKey: dictionaryKey) {
+    currencyKey = currencyValue
+  } else {
+    userDefaults.setValue(currencyKey, forKey: dictionaryKey)
+  }
+  if let index = currencyKeys.firstIndex(of: currencyKey) {
+    currencyKeys.remove(at: index)
+  }
 
   if DeviceType.isPhone {
     if userDefaults.bool(forKey: "deAccentCharacters") {
-      letterKeys = GermanKeyboardConstants.letterKeysPhoneDisableAccents
+      letterKeys = GermanKeyboardProvider.genPhoneDisableAccentsLetterKeys()
     } else {
-      letterKeys = GermanKeyboardConstants.letterKeysPhone
+      letterKeys = GermanKeyboardProvider.genPhoneLetterKeys()
     }
-    numberKeys = GermanKeyboardConstants.numberKeysPhone
-    symbolKeys = GermanKeyboardConstants.symbolKeysPhone
+    numberKeys = GermanKeyboardProvider.genPhoneNumberKeys(currencyKey: currencyKey)
+    symbolKeys = GermanKeyboardProvider.genPhoneSymbolKeys(currencyKeys: currencyKeys)
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "a", "1", "-", "[", "_"]
@@ -151,21 +214,21 @@ func getDEKeys() {
     // Use the expanded keys layout if the iPad is wide enough and has no home button.
     if usingExpandedKeyboard {
       if userDefaults.bool(forKey: "deAccentCharacters") {
-        letterKeys = GermanKeyboardConstants.letterKeysPadExpandedDisableAccents
+        letterKeys = GermanKeyboardProvider.genPadExpandedDisableAccentsLetterKeys()
       } else {
-        letterKeys = GermanKeyboardConstants.letterKeysPadExpanded
+        letterKeys = GermanKeyboardProvider.genPadExpandedLetterKeys()
       }
-      symbolKeys = GermanKeyboardConstants.symbolKeysPadExpanded
+      symbolKeys = GermanKeyboardProvider.genPadExpandedSymbolKeys()
 
       allKeys = Array(letterKeys.joined()) + Array(symbolKeys.joined())
     } else {
       if userDefaults.bool(forKey: "deAccentCharacters") {
-        letterKeys = GermanKeyboardConstants.letterKeysPadDisableAccents
+        letterKeys = GermanKeyboardProvider.genPadDisableAccentsLetterKeys()
       } else {
-        letterKeys = GermanKeyboardConstants.letterKeysPad
+        letterKeys = GermanKeyboardProvider.genPadLetterKeys()
       }
-      numberKeys = GermanKeyboardConstants.numberKeysPad
-      symbolKeys = GermanKeyboardConstants.symbolKeysPad
+      numberKeys = GermanKeyboardProvider.genPadNumberKeys(currencyKey: currencyKey)
+      symbolKeys = GermanKeyboardProvider.genPadSymbolKeys(currencyKeys: currencyKeys)
 
       letterKeys.removeFirst(1)
 

--- a/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
@@ -84,7 +84,6 @@ struct GermanKeyboardProvider: KeyboardProviderProtocol, KeyboardProviderDisable
     if currencyKeys.count < 3 {
       return keyboardBuilder.build()
     } else {
-      // Replace currencies
       return keyboardBuilder
         .replaceKey(row: 1, column: 6, to: currencyKeys[0])
         .replaceKey(row: 1, column: 7, to: currencyKeys[1])
@@ -134,7 +133,6 @@ struct GermanKeyboardProvider: KeyboardProviderProtocol, KeyboardProviderDisable
     if currencyKeys.count < 3 {
       return keyboardBuilder.build()
     } else {
-      // Replace currencies
       return keyboardBuilder
         .replaceKey(row: 1, column: 0, to: currencyKeys[0])
         .replaceKey(row: 1, column: 1, to: currencyKeys[1])

--- a/Keyboards/LanguageKeyboards/Hebrew/HEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Hebrew/HEInterfaceVariables.swift
@@ -20,72 +20,113 @@
 import UIKit
 
 public enum HebrewKeyboardConstants {
-  // iPhone keyboard layouts.
-  static let letterKeysPhone = [
-    ["פ", "ם", "ן", "ו", "ט", "א", "ר", "ק", "delete"],
-    ["ף", "ך", "ל", "ח", "י", "ע", "כ", "ג", "ד", "ש"],
-    ["ץ", "ת", "צ", "מ", "נ", "ה", "ב", "ס", "ז"],
-    ["123", "selectKeyboard", "space", "return"] // "undo", "accent"
-  ]
-
-  static let numberKeysPhone = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
-    ["-", "/", ":", ";", "(", ")", "$", "&", "@", "\""],
-    ["#+=", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo", "accent"
-  ]
-
-  static let symbolKeysPhone = [
-    ["[", "]", "{", "}", "#", "%", "^", "*", "+", "="],
-    ["_", "\\", "|", "~", "<", ">", "€", "£", "¥", "·"],
-    ["123", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo", "accent"
-  ]
-
-  // iPad keyboard layouts.
-  static let letterKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
-    [",", ".", "פ", "ם", "ן", "ו", "ט", "א", "ר", "ק", "delete"],
-    ["ף", "ך", "ל", "ח", "י", "ע", "כ", "ג", "ד", "ש"],
-    ["ץ", "ת", "צ", "מ", "נ", "ה", "ב", "ס", "ז", "return"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "undo"
-  ]
-
-  static let numberKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"],
-    ["!", "@", "#", "&", "_", "-", "'", "\"", "(", ")", "return"],
-    ["#+=", "%", "...", "&", ";", ":", "=", "+", "/", "?", "#+="],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  static let symbolKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "*", "delete"],
-    ["^", "€", "$", "£", "[", "]", "'", "\"", "<", ">", "return"],
-    ["123", "§", "|", "~", "*", "·", "{", "}", "\\", "~", "123"],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  // Expanded iPad keyboard layouts for wider devices.
-  static let letterKeysPadExpanded = [
-    ["§", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "delete"],
-    [SpecialKeys.indent, "/", "'", "פ", "ם", "ן", "ו", "ט", "א", "ר", "ק", "[", "]", "+"],
-    [SpecialKeys.capsLock, "ף", "ך", "ל", "ח", "י", "ע", "כ", "ג", "ד", "ש", ",", "\"", "return"], // "accent"
-    ["shift", ";", "ץ", "ת", "צ", "מ", "נ", "ה", "ב", "ס", "ז", ".", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "microphone", "scribble"
-  ]
-
-  static let symbolKeysPadExpanded = [
-    ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "—"],
-    [SpecialKeys.capsLock, "°", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "€", "return"], // "undo"
-    ["shift", "…", "?", "!", "~", "≠", "'", "\"", "_", ",", ".", "-", "shift"], // "redo"
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "microphone", "scribble"
-  ]
+  static let defaultCurrencyKey = "$"
+  static let currencyKeys = ["$", "€", "£", "¥"]
 
   // Alternate key vars.
   static let keysWithAlternates = [""]
   static let keysWithAlternatesLeft = [""]
   static let keysWithAlternatesRight = [""]
+}
+
+struct HebrewKeyboardProvider: KeyboardProviderProtocol {
+  // iPhone keyboard layouts.
+  static func genPhoneLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["פ", "ם", "ן", "ו", "ט", "א", "ר", "ק", "delete"])
+      .addRow(["ף", "ך", "ל", "ח", "י", "ע", "כ", "ג", "ד", "ש"])
+      .addRow(["ץ", "ת", "צ", "מ", "נ", "ה", "ב", "ס", "ז"])
+      .addRow(["123", "selectKeyboard", "space", "return"]) // "undo", "accent"
+      .build()
+  }
+
+  static func genPhoneNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"])
+      .addRow(["-", "/", ":", ";", "(", ")", "$", "&", "@", "\""])
+      .addRow(["#+=", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo", "accent"
+      .replaceKey(row: 1, column: 6, to: currencyKey)
+      .build()
+  }
+
+  static func genPhoneSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder = KeyboardBuilder()
+      .addRow(["[", "]", "{", "}", "#", "%", "^", "*", "+", "="])
+      .addRow(["_", "\\", "|", "~", "<", ">", "€", "£", "¥", "·"])
+      .addRow(["123", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo", "accent"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 6, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 7, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 8, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // iPad keyboard layouts.
+  static func genPadLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"])
+      .addRow([",", ".", "פ", "ם", "ן", "ו", "ט", "א", "ר", "ק", "delete"])
+      .addRow(["ף", "ך", "ל", "ח", "י", "ע", "כ", "ג", "ד", "ש"])
+      .addRow(["ץ", "ת", "צ", "מ", "נ", "ה", "ב", "ס", "ז", "return"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "undo"
+      .build()
+  }
+
+  static func genPadNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"])
+      .addRow(["!", "@", "#", "&", "_", "-", "'", "\"", "(", ")", "return"])
+      .addRow(["#+=", "%", "...", "&", ";", ":", "=", "+", "/", "?", "#+="])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+      // .replaceKey(row: 1, column: 4, to: currencyKey)
+      .build()
+  }
+
+  static func genPadSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder = KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "*", "delete"])
+      .addRow(["^", "€", "$", "£", "[", "]", "'", "\"", "<", ">", "return"])
+      .addRow(["123", "§", "|", "~", "*", "·", "{", "}", "\\", "~", "123"])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 1, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 2, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 3, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // Expanded iPad keyboard layouts for wider devices.
+  static func genPadExpandedLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["§", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "delete"])
+      .addRow([SpecialKeys.indent, "/", "'", "פ", "ם", "ן", "ו", "ט", "א", "ר", "ק", "[", "]", "+"])
+      .addRow([SpecialKeys.capsLock, "ף", "ך", "ל", "ח", "י", "ע", "כ", "ג", "ד", "ש", ",", "\"", "return"])
+      .addRow(["shift", ";", "ץ", "ת", "צ", "מ", "נ", "ה", "ב", "ס", "ז", ".", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+
+  static func genPadExpandedSymbolKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"])
+      .addRow([SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "—"])
+      .addRow([SpecialKeys.capsLock, "°", "/", ":", ";", "(", ")", "$", "&", "@", "£", "¥", "€", "return"]) // "undo"
+      .addRow(["shift", "…", "?", "!", "~", "≠", "'", "\"", "_", ",", ".", "-", "shift"]) // "redo"
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
 }
 
 /// Gets the keys for the Hebrew keyboard.

--- a/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
@@ -69,7 +69,6 @@ struct ItalianKeyboardProvider: KeyboardProviderProtocol {
     if currencyKeys.count < 3 {
       return keyboardBuilder.build()
     } else {
-      // Replace currencies
       return keyboardBuilder
         .replaceKey(row: 1, column: 6, to: currencyKeys[0])
         .replaceKey(row: 1, column: 7, to: currencyKeys[1])
@@ -109,7 +108,6 @@ struct ItalianKeyboardProvider: KeyboardProviderProtocol {
     if currencyKeys.count < 3 {
       return keyboardBuilder.build()
     } else {
-      // Replace currencies
       return keyboardBuilder
         .replaceKey(row: 1, column: 0, to: currencyKeys[0])
         .replaceKey(row: 1, column: 1, to: currencyKeys[1])

--- a/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
@@ -20,67 +20,8 @@
 import UIKit
 
 public enum ItalianKeyboardConstants {
-  // iPhone keyboard layouts.
-  static let letterKeysPhone = [
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l"],
-    ["shift", "z", "x", "c", "v", "b", "n", "m", "delete"],
-    ["123", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let numberKeysPhone = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
-    ["-", "/", ":", ";", "(", ")", "€", "&", "@", "\""],
-    ["#+=", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let symbolKeysPhone = [
-    ["[", "]", "{", "}", "#", "%", "^", "*", "+", "="],
-    ["_", "\\", "|", "~", "<", ">", "$", "£", "¥", "·"],
-    ["123", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  // iPad keyboard layouts.
-  static let letterKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"],
-    ["shift", "z", "x", "c", "v", "b", "n", "m", ",", ".", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "undo"
-  ]
-
-  static let numberKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"],
-    ["@", "#", "€", "&", "*", "(", ")", "'", "\"", "return"],
-    ["#+=", "%", "-", "+", "=", "/", ";", ":", ",", ".", "#+="],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  static let symbolKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"],
-    ["$", "£", "¥", "_", "^", "[", "]", "{", "}", "return"],
-    ["123", "§", "|", "~", "...", "\\", "<", ">", "!", "?", "123"],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  // Expanded iPad keyboard layouts for wider devices.
-  static let letterKeysPadExpanded = [
-    ["\\", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "‘", "ì", "delete"],
-    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "è", "+", "*"],
-    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "ò", "à", "ù", "return"],
-    ["shift", "'", "z", "x", "c", "v", "b", "n", "m", "-", ",", ".", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "microphone", "scribble"
-  ]
-
-  static let symbolKeysPadExpanded = [
-    ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "§"],
-    [SpecialKeys.capsLock, "°", "/", ":", ";", "(", ")", "&", "@", "$", "£", "¥", "~", "return"], // "undo"
-    ["shift", "…", "?", "!", "≠", "'", "\"", "_", "€", "-", ",", ".", "shift"], // "shift"
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "microphone", "scribble"
-  ]
+  static let defaultCurrencyKey = "€"
+  static let currencyKeys = ["€", "$", "£", "¥"]
 
   // Alternate key vars.
   static let keysWithAlternates = ["a", "e", "i", "o", "u", "c", "n", "s"]
@@ -97,12 +38,130 @@ public enum ItalianKeyboardConstants {
   static let sAlternateKeys = ["ß", "ś", "š"]
 }
 
+struct ItalianKeyboardProvider: KeyboardProviderProtocol {
+  // iPhone keyboard layouts.
+  static func genPhoneLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l"])
+      .addRow(["shift", "z", "x", "c", "v", "b", "n", "m", "delete"])
+      .addRow(["123", "selectKeyboard", "space", "return"]) // "undo"
+      .build()
+  }
+
+  static func genPhoneNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"])
+      .addRow(["-", "/", ":", ";", "(", ")", "€", "&", "@", "\""])
+      .addRow(["#+=", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+      .replaceKey(row: 1, column: 6, to: currencyKey)
+      .build()
+  }
+
+  static func genPhoneSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder =  KeyboardBuilder()
+      .addRow(["[", "]", "{", "}", "#", "%", "^", "*", "+", "="])
+      .addRow(["_", "\\", "|", "~", "<", ">", "$", "£", "¥", "·"])
+      .addRow(["123", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      // Replace currencies
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 6, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 7, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 8, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // iPad keyboard layouts.
+  static func genPadLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"])
+      .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"])
+      .addRow(["shift", "z", "x", "c", "v", "b", "n", "m", ",", ".", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "undo"
+      .build()
+  }
+
+  static func genPadNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"])
+      .addRow(["@", "#", "€", "&", "*", "(", ")", "'", "\"", "return"])
+      .addRow(["#+=", "%", "-", "+", "=", "/", ";", ":", ",", ".", "#+="])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+      .replaceKey(row: 1, column: 2, to: currencyKey)
+      .build()
+  }
+
+  static func genPadSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder = KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"])
+      .addRow(["$", "£", "¥", "_", "^", "[", "]", "{", "}", "return"])
+      .addRow(["123", "§", "|", "~", "...", "\\", "<", ">", "!", "?", "123"])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      // Replace currencies
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 0, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 1, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 2, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // Expanded iPad keyboard layouts for wider devices.
+  static func genPadExpandedLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["\\", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "‘", "ì", "delete"])
+      .addRow([SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "è", "+", "*"])
+      .addRow([SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "ò", "à", "ù", "return"])
+      .addRow(["shift", "'", "z", "x", "c", "v", "b", "n", "m", "-", ",", ".", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+
+  static func genPadExpandedSymbolKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"])
+      .addRow([SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "§"])
+      .addRow([SpecialKeys.capsLock, "°", "/", ":", ";", "(", ")", "&", "@", "$", "£", "¥", "~", "return"]) // "undo"
+      .addRow(["shift", "…", "?", "!", "≠", "'", "\"", "_", "€", "-", ",", ".", "shift"]) // "shift"
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+}
+
 /// Gets the keys for the Italian keyboard.
 func getITKeys() {
+  guard let userDefaults = UserDefaults(suiteName: "group.be.scri.userDefaultsContainer") else {
+    fatalError()
+  }
+
+  var currencyKey = ItalianKeyboardConstants.defaultCurrencyKey
+  var currencyKeys = ItalianKeyboardConstants.currencyKeys
+  let dictionaryKey = controllerLanguage + "defaultCurrencySymbol"
+  if let currencyValue = userDefaults.string(forKey: dictionaryKey) {
+    currencyKey = currencyValue
+  } else {
+    userDefaults.setValue(currencyKey, forKey: dictionaryKey)
+  }
+  if let index = currencyKeys.firstIndex(of: currencyKey) {
+    currencyKeys.remove(at: index)
+  }
+
   if DeviceType.isPhone {
-    letterKeys = ItalianKeyboardConstants.letterKeysPhone
-    numberKeys = ItalianKeyboardConstants.numberKeysPhone
-    symbolKeys = ItalianKeyboardConstants.symbolKeysPhone
+    letterKeys = ItalianKeyboardProvider.genPhoneLetterKeys()
+    numberKeys = ItalianKeyboardProvider.genPhoneNumberKeys(currencyKey: currencyKey)
+    symbolKeys = ItalianKeyboardProvider.genPhoneSymbolKeys(currencyKeys: currencyKeys)
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "1", "-", "[", "_"]
@@ -111,14 +170,14 @@ func getITKeys() {
   } else {
     // Use the expanded keys layout if the iPad is wide enough and has no home button.
     if usingExpandedKeyboard {
-      letterKeys = ItalianKeyboardConstants.letterKeysPadExpanded
-      symbolKeys = ItalianKeyboardConstants.symbolKeysPadExpanded
+      letterKeys = ItalianKeyboardProvider.genPadExpandedLetterKeys()
+      symbolKeys = ItalianKeyboardProvider.genPadExpandedSymbolKeys()
 
       allKeys = Array(letterKeys.joined()) + Array(symbolKeys.joined())
     } else {
-      letterKeys = ItalianKeyboardConstants.letterKeysPad
-      numberKeys = ItalianKeyboardConstants.numberKeysPad
-      symbolKeys = ItalianKeyboardConstants.symbolKeysPad
+      letterKeys = ItalianKeyboardProvider.genPadLetterKeys()
+      numberKeys = ItalianKeyboardProvider.genPadNumberKeys(currencyKey: currencyKey)
+      symbolKeys = ItalianKeyboardProvider.genPadSymbolKeys(currencyKeys: currencyKeys)
 
       letterKeys.removeFirst(1)
 

--- a/Keyboards/LanguageKeyboards/Norwegian/NBInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Norwegian/NBInterfaceVariables.swift
@@ -20,67 +20,8 @@
 import UIKit
 
 public enum NorwegianBokmålKeyboardConstants {
-  // iPhone keyboard layouts.
-  static let letterKeysPhone = [
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ø", "æ"],
-    ["shift", "z", "x", "c", "v", "b", "n", "m", "delete"],
-    ["123", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let numberKeysPhone = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
-    ["-", "/", ":", ";", "(", ")", "$", "&", "@", "\""],
-    ["#+=", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let symbolKeysPhone = [
-    ["[", "]", "{", "}", "#", "%", "^", "*", "+", "="],
-    ["_", "\\", "|", "~", "<", ">", "€", "£", "¥", "·"],
-    ["123", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  // iPad keyboard layouts.
-  static let letterKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å", "delete"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ø", "æ", "return"],
-    ["shift", "z", "x", "c", "v", "b", "n", "m", ",", ".", "?", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "undo"
-  ]
-
-  static let numberKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "`", "delete"],
-    ["@", "#", "kr", "&", "*", "(", ")", "'", "\"", "+", "·", "return"],
-    ["#+=", "%", "_", "-", "=", "/", ";", ":", ",", ".", "≈", "#+="],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  static let symbolKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "*", "delete"],
-    ["€", "$", "£", "^", "[", "]", "{", "}", "―", "ᵒ", "...", "return"],
-    ["123", "§", "±", "|", "~", "≠", "\\", "<", ">", "!", "?", "123"],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  // Expanded iPad keyboard layouts for wider devices.
-  static let letterKeysPadExpanded = [
-    ["§", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "+", "´", "delete"],
-    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å", "^", "*"],
-    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "ø", "æ", "@", "return"],
-    ["shift", "'", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "microphone", "scribble"
-  ]
-
-  static let symbolKeysPadExpanded = [
-    ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "°"],
-    [SpecialKeys.capsLock, "—", "/", ":", ";", "(", ")", "&", "@", "$", "£", "¥", "~", "return"], // "undo"
-    ["shift", "…", "?", "!", "≠", "'", "\"", "_", "€", ",", ".", "-", "shift"], // "redo"
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "microphone", "scribble"
-  ]
+  static let defaultCurrencyKey = "kr"
+  static let currencyKeys = ["kr", "€", "$", "£", "¥"]
 
   // Alternate key vars.
   static let keysWithAlternates = ["a", "e", "o", "u", "ä", "ö"]
@@ -93,6 +34,106 @@ public enum NorwegianBokmålKeyboardConstants {
   static let uAlternateKeys = ["ū", "ú", "ù", "û", "ü"]
   static let æAlternateKeys = ["ä"]
   static let øAlternateKeys = ["ö"]
+}
+
+struct NorwegianBokmålKeyboardProvider: KeyboardProviderProtocol {
+  // iPhone keyboard layouts.
+  static func genPhoneLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "ø", "æ"])
+      .addRow(["shift", "z", "x", "c", "v", "b", "n", "m", "delete"])
+      .addRow(["123", "selectKeyboard", "space", "return"]) // "undo"
+      .build()
+  }
+
+  static func genPhoneNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"])
+      .addRow(["-", "/", ":", ";", "(", ")", "kr", "&", "@", "\""])
+      .addRow(["#+=", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+      .replaceKey(row: 1, column: 6, to: currencyKey)
+      .build()
+  }
+
+  static func genPhoneSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder = KeyboardBuilder()
+      .addRow(["[", "]", "{", "}", "#", "%", "^", "*", "+", "="])
+      .addRow(["_", "\\", "|", "~", "<", ">", "€", "$", "£", "·"])
+      .addRow(["123", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 6, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 7, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 8, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // iPad keyboard layouts.
+  static func genPadLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"])
+      .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å", "delete"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "ø", "æ", "return"])
+      .addRow(["shift", "z", "x", "c", "v", "b", "n", "m", ",", ".", "?", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "undo"
+      .build()
+  }
+
+  static func genPadNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "`", "delete"])
+      .addRow(["@", "#", "kr", "&", "*", "(", ")", "'", "\"", "+", "·", "return"])
+      .addRow(["#+=", "%", "_", "-", "=", "/", ";", ":", ",", ".", "≈", "#+="])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+      .replaceKey(row: 1, column: 2, to: currencyKey)
+      .build()
+  }
+
+  static func genPadSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder = KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "*", "delete"])
+      .addRow(["€", "$", "£", "^", "[", "]", "{", "}", "―", "ᵒ", "...", "return"])
+      .addRow(["123", "§", "±", "|", "~", "≠", "\\", "<", ">", "!", "?", "123"])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 0, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 1, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 2, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // Expanded iPad keyboard layouts for wider devices.
+  static func genPadExpandedLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["§", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "+", "´", "delete"])
+      .addRow([SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å", "^", "*"])
+      .addRow([SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "ø", "æ", "@", "return"])
+      .addRow(["shift", "'", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+
+  static func genPadExpandedSymbolKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"])
+      .addRow([SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\"", "|", "°"])
+      .addRow([SpecialKeys.capsLock, "—", "/", ":", ";", "(", ")", "&", "@", "$", "£", "¥", "~", "return"]) // "undo"
+      .addRow(["shift", "…", "?", "!", "≠", "'", "\"", "_", "€", ",", ".", "-", "shift"]) // "redo"
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
 }
 
 /// Gets the keys for the Norwegian Bokmål keyboard.

--- a/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
@@ -20,67 +20,8 @@
 import UIKit
 
 public enum PortugueseKeyboardConstants {
-  // iPhone keyboard layouts.
-  static let letterKeysPhone = [
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l"],
-    ["shift", "z", "x", "c", "v", "b", "n", "m", "delete"],
-    ["123", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let numberKeysPhone = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
-    ["-", "/", ":", ";", "(", ")", "€", "&", "@", "\""],
-    ["#+=", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let symbolKeysPhone = [
-    ["[", "]", "{", "}", "#", "%", "^", "*", "+", "="],
-    ["_", "\\", "|", "~", "<", ">", "$", "£", "¥", "·"],
-    ["123", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  // iPad keyboard layouts.
-  static let letterKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"],
-    ["shift", "z", "x", "c", "v", "b", "n", "m", "!", "?", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "undo"
-  ]
-
-  static let numberKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"],
-    ["@", "#", "$", "&", "*", "(", ")", "'", "\"", "return"],
-    ["#+=", "%", "-", "+", "=", "/", ";", ":", ",", ".", "#+="],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  static let symbolKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"],
-    ["€", "£", "¥", "_", "^", "[", "]", "{", "}", "return"],
-    ["123", "§", "|", "~", "...", "\\", "<", ">", "!", "?", "123"],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  // Expanded iPad keyboard layouts for wider devices.
-  static let letterKeysPadExpanded = [
-    ["~", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "delete"],
-    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]", "\\"],
-    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", ":", ";", "ç", "return"],
-    ["shift", "'", "z", "x", "c", "v", "b", "n", "m", ",", ".", "/", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "microphone", "scribble"
-  ]
-
-  static let symbolKeysPadExpanded = [
-    ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "—", "|", "~"],
-    [SpecialKeys.capsLock, "°", "\\", ":", ";", "(", ")", "&", "@", "$", "£", "¥", "€", "return"], // "undo"
-    ["shift", "…", "?", "!", "≠", "'", "\"", "_", "-", ",", ".", "/", "shift"], // "redo"
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "microphone", "scribble"
-  ]
+  static let defaultCurrencyKey = "€"
+  static let currencyKeys = ["€", "$", "£", "¥"]
 
   // Alternate key vars.
   static let keysWithAlternates = ["a", "e", "i", "o", "u", "c", "n"]
@@ -96,12 +37,130 @@ public enum PortugueseKeyboardConstants {
   static let nAlternateKeys = ["ñ"]
 }
 
+struct PortugueseKeyboardProvider: KeyboardProviderProtocol {
+  // iPhone keyboard layouts.
+  static func genPhoneLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l"])
+      .addRow(["shift", "z", "x", "c", "v", "b", "n", "m", "delete"])
+      .addRow(["123", "selectKeyboard", "space", "return"]) // "undo"
+      .build()
+  }
+
+  static func genPhoneNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"])
+      .addRow(["-", "/", ":", ";", "(", ")", "€", "&", "@", "\""])
+      .addRow(["#+=", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+      .replaceKey(row: 1, column: 6, to: currencyKey)
+      .build()
+  }
+
+  static func genPhoneSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder =  KeyboardBuilder()
+      .addRow(["[", "]", "{", "}", "#", "%", "^", "*", "+", "="])
+      .addRow(["_", "\\", "|", "~", "<", ">", "$", "£", "¥", "·"])
+      .addRow(["123", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      // Replace currencies
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 6, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 7, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 8, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // iPad keyboard layouts.
+  static func genPadLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"])
+      .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"])
+      .addRow(["shift", "z", "x", "c", "v", "b", "n", "m", "!", "?", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "undo"
+      .build()
+  }
+
+  static func genPadNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"])
+      .addRow(["@", "#", "$", "&", "*", "(", ")", "'", "\"", "return"])
+      .addRow(["#+=", "%", "-", "+", "=", "/", ";", ":", ",", ".", "#+="])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+      .replaceKey(row: 1, column: 2, to: currencyKey)
+      .build()
+  }
+
+  static func genPadSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder = KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"])
+      .addRow(["€", "£", "¥", "_", "^", "[", "]", "{", "}", "return"])
+      .addRow(["123", "§", "|", "~", "...", "\\", "<", ">", "!", "?", "123"])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      // Replace currencies
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 0, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 1, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 2, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // Expanded iPad keyboard layouts for wider devices.
+  static func genPadExpandedLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["~", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "delete"])
+      .addRow([SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]", "\\"])
+      .addRow([SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", ":", ";", "ç", "return"])
+      .addRow(["shift", "'", "z", "x", "c", "v", "b", "n", "m", ",", ".", "/", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+
+  static func genPadExpandedSymbolKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"])
+      .addRow([SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "—", "|", "~"])
+      .addRow([SpecialKeys.capsLock, "°", "\\", ":", ";", "(", ")", "&", "@", "$", "£", "¥", "€", "return"]) // "undo"
+      .addRow(["shift", "…", "?", "!", "≠", "'", "\"", "_", "-", ",", ".", "/", "shift"]) // "redo"
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+}
+
 /// Gets the keys for the Portuguese keyboard.
 func getPTKeys() {
+  guard let userDefaults = UserDefaults(suiteName: "group.be.scri.userDefaultsContainer") else {
+    fatalError()
+  }
+
+  var currencyKey = PortugueseKeyboardConstants.defaultCurrencyKey
+  var currencyKeys = PortugueseKeyboardConstants.currencyKeys
+  let dictionaryKey = controllerLanguage + "defaultCurrencySymbol"
+  if let currencyValue = userDefaults.string(forKey: dictionaryKey) {
+    currencyKey = currencyValue
+  } else {
+    userDefaults.setValue(currencyKey, forKey: dictionaryKey)
+  }
+  if let index = currencyKeys.firstIndex(of: currencyKey) {
+    currencyKeys.remove(at: index)
+  }
+
   if DeviceType.isPhone {
-    letterKeys = PortugueseKeyboardConstants.letterKeysPhone
-    numberKeys = PortugueseKeyboardConstants.numberKeysPhone
-    symbolKeys = PortugueseKeyboardConstants.symbolKeysPhone
+    letterKeys = PortugueseKeyboardProvider.genPhoneLetterKeys()
+    numberKeys = PortugueseKeyboardProvider.genPhoneNumberKeys(currencyKey: currencyKey)
+    symbolKeys = PortugueseKeyboardProvider.genPhoneSymbolKeys(currencyKeys: currencyKeys)
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "1", "-", "[", "_"]
@@ -110,14 +169,14 @@ func getPTKeys() {
   } else {
     // Use the expanded keys layout if the iPad is wide enough and has no home button.
     if usingExpandedKeyboard {
-      letterKeys = PortugueseKeyboardConstants.letterKeysPadExpanded
-      symbolKeys = PortugueseKeyboardConstants.symbolKeysPadExpanded
+      letterKeys = PortugueseKeyboardProvider.genPadExpandedLetterKeys()
+      symbolKeys = PortugueseKeyboardProvider.genPadExpandedSymbolKeys()
 
       allKeys = Array(letterKeys.joined()) + Array(symbolKeys.joined())
     } else {
-      letterKeys = PortugueseKeyboardConstants.letterKeysPad
-      numberKeys = PortugueseKeyboardConstants.numberKeysPad
-      symbolKeys = PortugueseKeyboardConstants.symbolKeysPad
+      letterKeys = PortugueseKeyboardProvider.genPadLetterKeys()
+      numberKeys = PortugueseKeyboardProvider.genPadNumberKeys(currencyKey: currencyKey)
+      symbolKeys = PortugueseKeyboardProvider.genPadSymbolKeys(currencyKeys: currencyKeys)
 
       letterKeys.removeFirst(1)
 

--- a/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
@@ -68,7 +68,6 @@ struct PortugueseKeyboardProvider: KeyboardProviderProtocol {
     if currencyKeys.count < 3 {
       return keyboardBuilder.build()
     } else {
-      // Replace currencies
       return keyboardBuilder
         .replaceKey(row: 1, column: 6, to: currencyKeys[0])
         .replaceKey(row: 1, column: 7, to: currencyKeys[1])
@@ -108,7 +107,6 @@ struct PortugueseKeyboardProvider: KeyboardProviderProtocol {
     if currencyKeys.count < 3 {
       return keyboardBuilder.build()
     } else {
-      // Replace currencies
       return keyboardBuilder
         .replaceKey(row: 1, column: 0, to: currencyKeys[0])
         .replaceKey(row: 1, column: 1, to: currencyKeys[1])

--- a/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
@@ -20,67 +20,8 @@
 import UIKit
 
 public enum RussianKeyboardConstants {
-  // iPhone keyboard layouts.
-  static let letterKeysPhone = [
-    ["й", "ц", "у", "к", "е", "н", "г", "ш", "щ", "з", "х"],
-    ["ф", "ы", "в", "а", "п", "р", "о", "л", "д", "ж", "э"],
-    ["shift", "я", "ч", "с", "м", "и", "т", "ь", "б", "ю", "delete"],
-    ["123", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let numberKeysPhone = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
-    ["-", "/", ":", ";", "(", ")", "₽", "&", "@", "\""],
-    ["#+=", ".", ",", "?", "!", "'", "delete"],
-    ["АБВ", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let symbolKeysPhone = [
-    ["[", "]", "{", "}", "#", "%", "^", "*", "+", "="],
-    ["_", "\\", "|", "~", "<", ">", "$", "€", "£", "·"],
-    ["123", ".", ",", "?", "!", "'", "delete"],
-    ["АБВ", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  // iPad keyboard layouts.
-  static let letterKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
-    ["й", "ц", "у", "к", "е", "н", "г", "ш", "щ", "з", "х", "delete"],
-    ["ф", "ы", "в", "а", "п", "р", "о", "л", "д", "ж", "э", "return"],
-    ["shift", "я", "ч", "с", "м", "и", "т", "ь", "б", "ю", ".", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "undo"
-  ]
-
-  static let numberKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "—", "delete"],
-    ["@", "#", "№", "₽", "ʼ", "&", "*", "(", ")", "'", "\"", "return"],
-    ["#+=", "%", "_", "-", "+", "=", "≠", ";", ":", ",", ".", "#+="],
-    ["selectKeyboard", "АБВ", "space", "АБВ", "hideKeyboard"] // "undo"
-  ]
-
-  static let symbolKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "—", "delete"],
-    ["$", "€", "£", "¥", "±", "·", "`", "[", "]", "{", "}", "return"],
-    ["123", "§", "|", "~", "...", "^", "\\", "<", ">", "!", "?", "123"],
-    ["selectKeyboard", "АБВ", "space", "АБВ", "hideKeyboard"] // "undo"
-  ]
-
-  // Expanded iPad keyboard layouts for wider devices.
-  static let letterKeysPadExpanded = [
-    ["§", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "delete"],
-    [SpecialKeys.indent, "й", "ц", "у", "к", "е", "н", "г", "ш", "щ", "з", "х", "ъ", "+"],
-    [SpecialKeys.capsLock, "ф", "ы", "в", "а", "п", "р", "о", "л", "д", "ж", "э", "ё", "return"],
-    ["shift", "'", "я", "ч", "с", "м", "и", "т", "ь", "б", "ю", "/", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "microphone", "scribble"
-  ]
-
-  static let symbolKeysPadExpanded = [
-    ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\\", "|", "₽"],
-    [SpecialKeys.capsLock, "—", "/", ":", ";", "(", ")", "&", "@", "$", "£", "¥", "~", "return"], // "undo"
-    ["shift", "…", "?", "!", "≠", "'", "\"", "_", "€", "-", ",", ".", "shift"], // "redo"
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "microphone", "scribble"
-  ]
+  static let defaultCurrencyKey = "₽"
+  static let currencyKeys = ["₽", "$", "€", "£"]
 
   // Alternate key vars.
   static let keysWithAlternates = ["е", "ь"]
@@ -91,12 +32,130 @@ public enum RussianKeyboardConstants {
   static let ьAlternateKeys = ["Ъ"]
 }
 
+struct RussianKeyboardProvider: KeyboardProviderProtocol {
+  // iPhone keyboard layouts.
+  static func genPhoneLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["й", "ц", "у", "к", "е", "н", "г", "ш", "щ", "з", "х"])
+      .addRow(["ф", "ы", "в", "а", "п", "р", "о", "л", "д", "ж", "э"])
+      .addRow(["shift", "я", "ч", "с", "м", "и", "т", "ь", "б", "ю", "delete"])
+      .addRow(["123", "selectKeyboard", "space", "return"]) // "undo"
+      .build()
+  }
+
+  static func genPhoneNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"])
+      .addRow(["-", "/", ":", ";", "(", ")", "₽", "&", "@", "\""])
+      .addRow(["#+=", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["АБВ", "selectKeyboard", "space", "return"]) // "undo"
+      .replaceKey(row: 1, column: 6, to: currencyKey)
+      .build()
+  }
+
+  static func genPhoneSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder =  KeyboardBuilder()
+      .addRow(["[", "]", "{", "}", "#", "%", "^", "*", "+", "="])
+      .addRow(["_", "\\", "|", "~", "<", ">", "$", "€", "£", "·"])
+      .addRow(["123", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["АБВ", "selectKeyboard", "space", "return"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      // Replace currencies
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 6, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 7, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 8, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // iPad keyboard layouts.
+  static func genPadLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"])
+      .addRow(["й", "ц", "у", "к", "е", "н", "г", "ш", "щ", "з", "х", "delete"])
+      .addRow(["ф", "ы", "в", "а", "п", "р", "о", "л", "д", "ж", "э", "return"])
+      .addRow(["shift", "я", "ч", "с", "м", "и", "т", "ь", "б", "ю", ".", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "undo"
+      .build()
+  }
+
+  static func genPadNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "—", "delete"])
+      .addRow(["@", "#", "№", "₽", "ʼ", "&", "*", "(", ")", "'", "\"", "return"])
+      .addRow(["#+=", "%", "_", "-", "+", "=", "≠", ";", ":", ",", ".", "#+="])
+      .addRow(["selectKeyboard", "АБВ", "space", "АБВ", "hideKeyboard"]) // "undo"
+      .replaceKey(row: 1, column: 3, to: currencyKey)
+      .build()
+  }
+
+  static func genPadSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder = KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "—", "delete"])
+      .addRow(["$", "€", "£", "¥", "±", "·", "`", "[", "]", "{", "}", "return"])
+      .addRow(["123", "§", "|", "~", "...", "^", "\\", "<", ">", "!", "?", "123"])
+      .addRow(["selectKeyboard", "АБВ", "space", "АБВ", "hideKeyboard"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      // Replace currencies
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 0, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 1, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 2, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // Expanded iPad keyboard layouts for wider devices.
+  static func genPadExpandedLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["§", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "delete"])
+      .addRow([SpecialKeys.indent, "й", "ц", "у", "к", "е", "н", "г", "ш", "щ", "з", "х", "ъ", "+"])
+      .addRow([SpecialKeys.capsLock, "ф", "ы", "в", "а", "п", "р", "о", "л", "д", "ж", "э", "ё", "return"])
+      .addRow(["shift", "'", "я", "ч", "с", "м", "и", "т", "ь", "б", "ю", "/", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+
+  static func genPadExpandedSymbolKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"])
+      .addRow([SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "\\", "|", "₽"])
+      .addRow([SpecialKeys.capsLock, "—", "/", ":", ";", "(", ")", "&", "@", "$", "£", "¥", "~", "return"]) // "undo"
+      .addRow(["shift", "…", "?", "!", "≠", "'", "\"", "_", "€", "-", ",", ".", "shift"]) // "redo"
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+}
+
 /// Gets the keys for the Russian keyboard.
 func getRUKeys() {
+  guard let userDefaults = UserDefaults(suiteName: "group.be.scri.userDefaultsContainer") else {
+    fatalError()
+  }
+
+  var currencyKey = RussianKeyboardConstants.defaultCurrencyKey
+  var currencyKeys = RussianKeyboardConstants.currencyKeys
+  let dictionaryKey = controllerLanguage + "defaultCurrencySymbol"
+  if let currencyValue = userDefaults.string(forKey: dictionaryKey) {
+    currencyKey = currencyValue
+  } else {
+    userDefaults.setValue(currencyKey, forKey: dictionaryKey)
+  }
+  if let index = currencyKeys.firstIndex(of: currencyKey) {
+    currencyKeys.remove(at: index)
+  }
+
   if DeviceType.isPhone {
-    letterKeys = RussianKeyboardConstants.letterKeysPhone
-    numberKeys = RussianKeyboardConstants.numberKeysPhone
-    symbolKeys = RussianKeyboardConstants.symbolKeysPhone
+    letterKeys = RussianKeyboardProvider.genPhoneLetterKeys()
+    numberKeys = RussianKeyboardProvider.genPhoneNumberKeys(currencyKey: currencyKey)
+    symbolKeys = RussianKeyboardProvider.genPhoneSymbolKeys(currencyKeys: currencyKeys)
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["й", "ф", "1", "-", "[", "_"]
@@ -105,14 +164,14 @@ func getRUKeys() {
   } else {
     // Use the expanded keys layout if the iPad is wide enough and has no home button.
     if usingExpandedKeyboard {
-      letterKeys = RussianKeyboardConstants.letterKeysPadExpanded
-      symbolKeys = RussianKeyboardConstants.symbolKeysPadExpanded
+      letterKeys = RussianKeyboardProvider.genPadExpandedLetterKeys()
+      symbolKeys = RussianKeyboardProvider.genPadExpandedSymbolKeys()
 
       allKeys = Array(letterKeys.joined()) + Array(symbolKeys.joined())
     } else {
-      letterKeys = RussianKeyboardConstants.letterKeysPad
-      numberKeys = RussianKeyboardConstants.numberKeysPad
-      symbolKeys = RussianKeyboardConstants.symbolKeysPad
+      letterKeys = RussianKeyboardProvider.genPadLetterKeys()
+      numberKeys = RussianKeyboardProvider.genPadNumberKeys(currencyKey: currencyKey)
+      symbolKeys = RussianKeyboardProvider.genPadSymbolKeys(currencyKeys: currencyKeys)
 
       letterKeys.removeFirst(1)
 

--- a/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
@@ -63,7 +63,6 @@ struct RussianKeyboardProvider: KeyboardProviderProtocol {
     if currencyKeys.count < 3 {
       return keyboardBuilder.build()
     } else {
-      // Replace currencies
       return keyboardBuilder
         .replaceKey(row: 1, column: 6, to: currencyKeys[0])
         .replaceKey(row: 1, column: 7, to: currencyKeys[1])
@@ -103,7 +102,6 @@ struct RussianKeyboardProvider: KeyboardProviderProtocol {
     if currencyKeys.count < 3 {
       return keyboardBuilder.build()
     } else {
-      // Replace currencies
       return keyboardBuilder
         .replaceKey(row: 1, column: 0, to: currencyKeys[0])
         .replaceKey(row: 1, column: 1, to: currencyKeys[1])

--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -80,7 +80,6 @@ struct SpanishKeyboardProvider: KeyboardProviderProtocol, KeyboardProviderDisabl
     if currencyKeys.count < 3 {
       return keyboardBuilder.build()
     } else {
-      // Replace currencies
       return keyboardBuilder
         .replaceKey(row: 1, column: 6, to: currencyKeys[0])
         .replaceKey(row: 1, column: 7, to: currencyKeys[1])
@@ -130,7 +129,6 @@ struct SpanishKeyboardProvider: KeyboardProviderProtocol, KeyboardProviderDisabl
     if currencyKeys.count < 3 {
       return keyboardBuilder.build()
     } else {
-      // Replace currencies
       return keyboardBuilder
         .replaceKey(row: 1, column: 0, to: currencyKeys[0])
         .replaceKey(row: 1, column: 1, to: currencyKeys[1])

--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -20,90 +20,8 @@
 import UIKit
 
 public enum SpanishKeyboardConstants {
-  // iPhone keyboard layouts.
-  static let letterKeysPhone = [
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ñ"],
-    ["shift", "z", "x", "c", "v", "b", "n", "m", "delete"],
-    ["123", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let letterKeysPhoneDisableAccents = [
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l"],
-    ["shift", "z", "x", "c", "v", "b", "n", "m", "delete"],
-    ["123", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let numberKeysPhone = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
-    ["-", "/", ":", ";", "(", ")", "$", "&", "@", "\""],
-    ["#+=", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let symbolKeysPhone = [
-    ["[", "]", "{", "}", "#", "%", "^", "*", "+", "="],
-    ["_", "\\", "|", "~", "<", ">", "€", "£", "¥", "·"],
-    ["123", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  // iPad keyboard layouts.
-  static let letterKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ñ", "return"],
-    ["shift", "z", "x", "c", "v", "b", "n", "m", ",", ".", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "undo"
-  ]
-
-  static let letterKeysPadDisableAccents = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
-    ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"],
-    ["shift", "z", "x", "c", "v", "b", "n", "m", ",", ".", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "undo"
-  ]
-
-  static let numberKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"],
-    ["@", "#", "$", "&", "*", "(", ")", "'", "\"", "+", "return"],
-    ["#+=", "%", "_", "-", "=", "/", ";", ":", ",", ".", "#+="],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  static let symbolKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"],
-    ["€", "£", "¥", "^", "[", "]", "{", "}", "ᵒ", "ᵃ", "return"],
-    ["123", "§", "|", "~", "¶", "\\", "<", ">", "¡", "¿", "123"],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  // Expanded iPad keyboard layouts for wider devices.
-  static let letterKeysPadExpanded = [
-    ["|", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "?", "¿", "delete"],
-    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "´", "+", "*"],
-    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "ñ", "{", "}", "return"],
-    ["shift", "'", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "microphone", "scribble"
-  ]
-
-  static let letterKeysPadExpandedDisableAccents = [
-    ["|", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "?", "¿", "delete"],
-    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "´", "+", "*"],
-    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "~", "{", "}", "return"],
-    ["shift", "'", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "microphone", "scribble"
-  ]
-
-  static let symbolKeysPadExpanded = [
-    ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    [SpecialKeys.indent, "(", ")", "{", "}", "#", "%", "^", "*", "+", "=", "\\", "|", "§"],
-    [SpecialKeys.capsLock, "—", "/", ":", ";", "&", "@", "$", "£", "¥", "~", "[", "]", "return"], // "undo"
-    ["shift", "…", "?", "!", "≠", "'", "\"", "_", "€", ",", ".", "-", "shift"], // "redo"
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "microphone", "scribble"
-  ]
+  static let defaultCurrencyKey = "$"
+  static let currencyKeys = ["$", "€", "£", "¥"]
 
   // Alternate key vars.
   static let keysWithAlternates = ["a", "e", "i", "o", "u", "c", "d", "n", "s"]
@@ -122,18 +40,163 @@ public enum SpanishKeyboardConstants {
   static let sAlternateKeys = ["š"]
 }
 
+struct SpanishKeyboardProvider: KeyboardProviderProtocol, KeyboardProviderDisableAccentsProtocol {
+  // iPhone keyboard layouts.
+  static func genPhoneLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "ñ"])
+      .addRow(["shift", "z", "x", "c", "v", "b", "n", "m", "delete"])
+      .addRow(["123", "selectKeyboard", "space", "return"]) // "undo"
+      .build()
+  }
+
+  static func genPhoneDisableAccentsLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l"])
+      .addRow(["shift", "z", "x", "c", "v", "b", "n", "m", "delete"])
+      .addRow(["123", "selectKeyboard", "space", "return"]) // "undo"
+      .build()
+  }
+
+  static func genPhoneNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"])
+      .addRow(["-", "/", ":", ";", "(", ")", "$", "&", "@", "\""])
+      .addRow(["#+=", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+      .replaceKey(row: 1, column: 6, to: currencyKey)
+      .build()
+  }
+
+  static func genPhoneSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder = KeyboardBuilder()
+      .addRow(["[", "]", "{", "}", "#", "%", "^", "*", "+", "="])
+      .addRow(["_", "\\", "|", "~", "<", ">", "€", "£", "¥", "·"])
+      .addRow(["123", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      // Replace currencies
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 6, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 7, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 8, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // iPad keyboard layouts.
+  static func genPadLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"])
+      .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "ñ", "return"])
+      .addRow(["shift", "z", "x", "c", "v", "b", "n", "m", ",", ".", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "undo"
+      .build()
+  }
+
+  static func genPadDisableAccentsLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"])
+      .addRow(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "delete"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"])
+      .addRow(["shift", "z", "x", "c", "v", "b", "n", "m", ",", ".", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "undo"
+      .build()
+  }
+
+  static func genPadNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"])
+      .addRow(["@", "#", "$", "&", "*", "(", ")", "'", "\"", "+", "return"])
+      .addRow(["#+=", "%", "_", "-", "=", "/", ";", ":", ",", ".", "#+="])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+      .replaceKey(row: 1, column: 2, to: currencyKey)
+      .build()
+  }
+
+  static func genPadSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder = KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "delete"])
+      .addRow(["€", "£", "¥", "^", "[", "]", "{", "}", "ᵒ", "ᵃ", "return"])
+      .addRow(["123", "§", "|", "~", "¶", "\\", "<", ">", "¡", "¿", "123"])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      // Replace currencies
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 0, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 1, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 2, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // Expanded iPad keyboard layouts for wider devices.
+  static func genPadExpandedLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+    .addRow(["|", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "?", "¿", "delete"])
+    .addRow([SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "´", "+", "*"])
+    .addRow([SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "ñ", "{", "}", "return"])
+    .addRow(["shift", "'", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"])
+    .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "microphone", "scribble"
+    .build()
+  }
+
+  static func genPadExpandedDisableAccentsLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+    .addRow(["|", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "?", "¿", "delete"])
+    .addRow([SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "´", "+", "*"])
+    .addRow([SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "~", "{", "}", "return"])
+    .addRow(["shift", "'", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"])
+    .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "microphone", "scribble"
+    .build()
+}
+
+static func genPadExpandedSymbolKeys() -> [[String]] {
+  return KeyboardBuilder()
+    .addRow(["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"])
+    .addRow([SpecialKeys.indent, "(", ")", "{", "}", "#", "%", "^", "*", "+", "=", "\\", "|", "§"])
+    .addRow([SpecialKeys.capsLock, "—", "/", ":", ";", "&", "@", "$", "£", "¥", "~", "[", "]", "return"]) // "undo"
+    .addRow(["shift", "…", "?", "!", "≠", "'", "\"", "_", "€", ",", ".", "-", "shift"]) // "redo"
+    .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "microphone", "scribble"
+    .build()
+}
+}
+
 /// Gets the keys for the Spanish keyboard.
 func getESKeys() {
-  let userDefaults = UserDefaults(suiteName: "group.be.scri.userDefaultsContainer")!
+  guard let userDefaults = UserDefaults(suiteName: "group.be.scri.userDefaultsContainer") else {
+    fatalError()
+  }
+
+  var currencyKey = SpanishKeyboardConstants.defaultCurrencyKey
+  var currencyKeys = SpanishKeyboardConstants.currencyKeys
+  let dictionaryKey = controllerLanguage + "defaultCurrencySymbol"
+  if let currencyValue = userDefaults.string(forKey: dictionaryKey) {
+    currencyKey = currencyValue
+  } else {
+    userDefaults.setValue(currencyKey, forKey: dictionaryKey)
+  }
+  if let index = currencyKeys.firstIndex(of: currencyKey) {
+    currencyKeys.remove(at: index)
+  }
 
   if DeviceType.isPhone {
     if userDefaults.bool(forKey: "esAccentCharacters") {
-      letterKeys = SpanishKeyboardConstants.letterKeysPhoneDisableAccents
+      letterKeys = SpanishKeyboardProvider.genPhoneDisableAccentsLetterKeys()
     } else {
-      letterKeys = SpanishKeyboardConstants.letterKeysPhone
+      letterKeys = SpanishKeyboardProvider.genPhoneLetterKeys()
     }
-    numberKeys = SpanishKeyboardConstants.numberKeysPhone
-    symbolKeys = SpanishKeyboardConstants.symbolKeysPhone
+    numberKeys = SpanishKeyboardProvider.genPhoneNumberKeys(currencyKey: currencyKey)
+    symbolKeys = SpanishKeyboardProvider.genPhoneSymbolKeys(currencyKeys: currencyKeys)
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "a", "1", "-", "[", "_"]
@@ -147,21 +210,21 @@ func getESKeys() {
     // Use the expanded keys layout if the iPad is wide enough and has no home button.
     if usingExpandedKeyboard {
       if userDefaults.bool(forKey: "esAccentCharacters") {
-        letterKeys = SpanishKeyboardConstants.letterKeysPadExpandedDisableAccents
+        letterKeys = SpanishKeyboardProvider.genPadExpandedDisableAccentsLetterKeys()
       } else {
-        letterKeys = SpanishKeyboardConstants.letterKeysPadExpanded
+        letterKeys = SpanishKeyboardProvider.genPadExpandedLetterKeys()
       }
-      symbolKeys = SpanishKeyboardConstants.symbolKeysPadExpanded
+      symbolKeys = SpanishKeyboardProvider.genPadExpandedSymbolKeys()
 
       allKeys = Array(letterKeys.joined()) + Array(symbolKeys.joined())
     } else {
       if userDefaults.bool(forKey: "esAccentCharacters") {
-        letterKeys = SpanishKeyboardConstants.letterKeysPadDisableAccents
+        letterKeys = SpanishKeyboardProvider.genPadDisableAccentsLetterKeys()
       } else {
-        letterKeys = SpanishKeyboardConstants.letterKeysPad
+        letterKeys = SpanishKeyboardProvider.genPadLetterKeys()
       }
-      numberKeys = SpanishKeyboardConstants.numberKeysPad
-      symbolKeys = SpanishKeyboardConstants.symbolKeysPad
+      numberKeys = SpanishKeyboardProvider.genPadNumberKeys(currencyKey: currencyKey)
+      symbolKeys = SpanishKeyboardProvider.genPadSymbolKeys(currencyKeys: currencyKeys)
 
       letterKeys.removeFirst(1)
 

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -84,7 +84,6 @@ struct SwedishKeyboardProvider: KeyboardProviderProtocol, KeyboardProviderDisabl
     if currencyKeys.count < 3 {
       return keyboardBuilder.build()
     } else {
-      // Replace currencies
       return keyboardBuilder
         .replaceKey(row: 1, column: 6, to: currencyKeys[0])
         .replaceKey(row: 1, column: 7, to: currencyKeys[1])
@@ -134,7 +133,6 @@ struct SwedishKeyboardProvider: KeyboardProviderProtocol, KeyboardProviderDisabl
     if currencyKeys.count < 3 {
       return keyboardBuilder.build()
     } else {
-      // Replace currencies
       return keyboardBuilder
         .replaceKey(row: 1, column: 0, to: currencyKeys[0])
         .replaceKey(row: 1, column: 1, to: currencyKeys[1])

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -20,90 +20,8 @@
 import UIKit
 
 public enum SwedishKeyboardConstants {
-  // iPhone keyboard layouts.
-  static let letterKeysPhone = [
-    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "å"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä"],
-    ["shift", "y", "x", "c", "v", "b", "n", "m", "delete"],
-    ["123", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let letterKeysPhoneDisableAccents = [
-    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l"],
-    ["shift", "y", "x", "c", "v", "b", "n", "m", "delete"],
-    ["123", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let numberKeysPhone = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
-    ["-", "/", ":", ";", "(", ")", "kr", "&", "@", "\""],
-    ["#+=", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  static let symbolKeysPhone = [
-    ["[", "]", "{", "}", "#", "%", "^", "*", "+", "="],
-    ["_", "\\", "|", "~", "<", ">", "€", "$", "£", "·"],
-    ["123", ".", ",", "?", "!", "'", "delete"],
-    ["ABC", "selectKeyboard", "space", "return"] // "undo"
-  ]
-
-  // iPad keyboard layouts.
-  static let letterKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
-    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "å", "delete"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "return"],
-    ["shift", "y", "x", "c", "v", "b", "n", "m", ",", ".", "?", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "undo"
-  ]
-
-  static let letterKeysPadDisableAccents = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"],
-    ["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "delete"],
-    ["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"],
-    ["shift", "y", "x", "c", "v", "b", "n", "m", ",", ".", "?", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "undo"
-  ]
-
-  static let numberKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "`", "delete"],
-    ["@", "#", "kr", "&", "*", "(", ")", "'", "\"", "+", "·", "return"],
-    ["#+=", "%", "≈", "±", "=", "/", ";", ":", ",", ".", "-", "#+="],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  static let symbolKeysPad = [
-    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "*", "delete"],
-    ["€", "$", "£", "^", "[", "]", "{", "}", "―", "ᵒ", "...", "return"],
-    ["123", "§", "|", "~", "≠", "\\", "<", ">", "!", "?", "_", "123"],
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "undo"
-  ]
-
-  // Expanded iPad keyboard layouts for wider devices.
-  static let letterKeysPadExpanded = [
-    ["§", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "+", "´", "delete"],
-    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å", "^", "*"],
-    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "'", "return"],
-    ["shift", "'", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "microphone", "scribble"
-  ]
-
-  static let letterKeysPadExpandedDisableAccents = [
-    ["§", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "+", "´", "delete"],
-    [SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "\"", "^", "*"],
-    [SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "(", ")", "'", "return"],
-    ["shift", "'", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"],
-    ["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"] // "microphone", "scribble"
-  ]
-
-  static let symbolKeysPadExpanded = [
-    ["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"],
-    [SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "°", "|", "§"],
-    [SpecialKeys.capsLock, "—", "/", ":", ";", "(", ")", "&", "@", "$", "£", "¥", "~", "return"], // "undo"
-    ["shift", "…", "?", "!", "≠", "'", "\"", "_", "€", ",", ".", "-", "shift"], // "redo"
-    ["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"] // "microphone", "scribble"
-  ]
+  static let defaultCurrencyKey = "kr"
+  static let currencyKeys = ["kr", "€", "$", "£"]
 
   // Alternate key vars.
   static let keysWithAlternates = ["a", "e", "i", "o", "u", "ä", "ö", "c", "n", "s"]
@@ -126,18 +44,166 @@ public enum SwedishKeyboardConstants {
   static let sAlternateKeys = ["ß", "ś", "š"]
 }
 
+struct SwedishKeyboardProvider: KeyboardProviderProtocol, KeyboardProviderDisableAccentsProtocol {
+  // iPhone keyboard layouts.
+  static func genPhoneLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "å"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä"])
+      .addRow(["shift", "y", "x", "c", "v", "b", "n", "m", "delete"])
+      .addRow(["123", "selectKeyboard", "space", "return"]) // "undo"
+      .build()
+  }
+
+  static func genPhoneDisableAccentsLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["q", "w", "e", "r", "t", "z", "u", "i", "o", "p"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l"])
+      .addRow(["shift", "y", "x", "c", "v", "b", "n", "m", "delete"])
+      .addRow(["123", "selectKeyboard", "space", "return"]) // "undo"
+      .build()
+  }
+
+  static func genPhoneNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"])
+      .addRow(["-", "/", ":", ";", "(", ")", "kr", "&", "@", "\""])
+      .addRow(["#+=", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+      .replaceKey(row: 1, column: 6, to: currencyKey)
+      .build()
+  }
+
+  static func genPhoneSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder =  KeyboardBuilder()
+      .addRow(["[", "]", "{", "}", "#", "%", "^", "*", "+", "="])
+      .addRow(["_", "\\", "|", "~", "<", ">", "€", "$", "£", "·"])
+      .addRow(["123", ".", ",", "?", "!", "'", "delete"])
+      .addRow(["ABC", "selectKeyboard", "space", "return"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      // Replace currencies
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 6, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 7, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 8, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // iPad keyboard layouts.
+  static func genPadLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"])
+      .addRow(["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "å", "delete"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "return"])
+      .addRow(["shift", "y", "x", "c", "v", "b", "n", "m", ",", ".", "?", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "undo"
+      .build()
+  }
+
+  static func genPadDisableAccentsLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "+"])
+      .addRow(["q", "w", "e", "r", "t", "z", "u", "i", "o", "p", "delete"])
+      .addRow(["a", "s", "d", "f", "g", "h", "j", "k", "l", "return"])
+      .addRow(["shift", "y", "x", "c", "v", "b", "n", "m", ",", ".", "?", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "undo"
+      .build()
+  }
+
+  static func genPadNumberKeys(currencyKey: String) -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "`", "delete"])
+      .addRow(["@", "#", "kr", "&", "*", "(", ")", "'", "\"", "+", "·", "return"])
+      .addRow(["#+=", "%", "≈", "±", "=", "/", ";", ":", ",", ".", "-", "#+="])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+      .replaceKey(row: 1, column: 2, to: currencyKey)
+      .build()
+  }
+
+  static func genPadSymbolKeys(currencyKeys: [String]) -> [[String]] {
+    let keyboardBuilder =  KeyboardBuilder()
+      .addRow(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "*", "delete"])
+      .addRow(["€", "$", "£", "^", "[", "]", "{", "}", "―", "ᵒ", "...", "return"])
+      .addRow(["123", "§", "|", "~", "≠", "\\", "<", ">", "!", "?", "_", "123"])
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "undo"
+
+    if currencyKeys.count < 3 {
+      return keyboardBuilder.build()
+    } else {
+      // Replace currencies
+      return keyboardBuilder
+        .replaceKey(row: 1, column: 0, to: currencyKeys[0])
+        .replaceKey(row: 1, column: 1, to: currencyKeys[1])
+        .replaceKey(row: 1, column: 2, to: currencyKeys[2])
+        .build()
+    }
+  }
+
+  // Expanded iPad keyboard layouts for wider devices.
+  static func genPadExpandedLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["§", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "+", "´", "delete"])
+      .addRow([SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "å", "^", "*"])
+      .addRow([SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "ö", "ä", "'", "return"])
+      .addRow(["shift", "'", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+
+  static func genPadExpandedDisableAccentsLetterKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["§", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "+", "´", "delete"])
+      .addRow([SpecialKeys.indent, "q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "\"", "^", "*"])
+      .addRow([SpecialKeys.capsLock, "a", "s", "d", "f", "g", "h", "j", "k", "l", "(", ")", "'", "return"])
+      .addRow(["shift", "'", "z", "x", "c", "v", "b", "n", "m", ",", ".", "-", "shift"])
+      .addRow(["selectKeyboard", ".?123", "space", ".?123", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+
+  static func genPadExpandedSymbolKeys() -> [[String]] {
+    return KeyboardBuilder()
+      .addRow(["`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "<", ">", "delete"])
+      .addRow([SpecialKeys.indent, "[", "]", "{", "}", "#", "%", "^", "*", "+", "=", "°", "|", "§"])
+      .addRow([SpecialKeys.capsLock, "—", "/", ":", ";", "(", ")", "&", "@", "$", "£", "¥", "~", "return"]) // "undo"
+      .addRow(["shift", "…", "?", "!", "≠", "'", "\"", "_", "€", ",", ".", "-", "shift"]) // "redo"
+      .addRow(["selectKeyboard", "ABC", "space", "ABC", "hideKeyboard"]) // "microphone", "scribble"
+      .build()
+  }
+
+}
+
+// MARK: Generate and set keyboard
+
 /// Gets the keys for the Swedish keyboard.
 func getSVKeys() {
-  let userDefaults = UserDefaults(suiteName: "group.be.scri.userDefaultsContainer")!
+  guard let userDefaults = UserDefaults(suiteName: "group.be.scri.userDefaultsContainer") else {
+    fatalError()
+  }
+
+  var currencyKey = SwedishKeyboardConstants.defaultCurrencyKey
+  var currencyKeys = SwedishKeyboardConstants.currencyKeys
+  let dictionaryKey = controllerLanguage + "defaultCurrencySymbol"
+  if let currencyValue = userDefaults.string(forKey: dictionaryKey) {
+    currencyKey = currencyValue
+  } else {
+    userDefaults.setValue(currencyKey, forKey: dictionaryKey)
+  }
+  if let index = currencyKeys.firstIndex(of: currencyKey) {
+    currencyKeys.remove(at: index)
+  }
 
   if DeviceType.isPhone {
     if userDefaults.bool(forKey: "svAccentCharacters") {
-      letterKeys = SwedishKeyboardConstants.letterKeysPhoneDisableAccents
+      letterKeys = SwedishKeyboardProvider.genPhoneDisableAccentsLetterKeys()
     } else {
-      letterKeys = SwedishKeyboardConstants.letterKeysPhone
+      letterKeys = SwedishKeyboardProvider.genPhoneLetterKeys()
     }
-    numberKeys = SwedishKeyboardConstants.numberKeysPhone
-    symbolKeys = SwedishKeyboardConstants.symbolKeysPhone
+    numberKeys = SwedishKeyboardProvider.genPhoneNumberKeys(currencyKey: currencyKey)
+    symbolKeys = SwedishKeyboardProvider.genPhoneSymbolKeys(currencyKeys: currencyKeys)
     allKeys = Array(letterKeys.joined()) + Array(numberKeys.joined()) + Array(symbolKeys.joined())
 
     leftKeyChars = ["q", "a", "1", "-", "[", "_"]
@@ -151,21 +217,21 @@ func getSVKeys() {
     // Use the expanded keys layout if the iPad is wide enough and has no home button.
     if usingExpandedKeyboard {
       if userDefaults.bool(forKey: "svAccentCharacters") {
-        letterKeys = SwedishKeyboardConstants.letterKeysPadExpandedDisableAccents
+        letterKeys = SwedishKeyboardProvider.genPadExpandedDisableAccentsLetterKeys()
       } else {
-        letterKeys = SwedishKeyboardConstants.letterKeysPadExpanded
+        letterKeys = SwedishKeyboardProvider.genPadExpandedLetterKeys()
       }
-      symbolKeys = SwedishKeyboardConstants.symbolKeysPadExpanded
+      symbolKeys = SwedishKeyboardProvider.genPadExpandedSymbolKeys()
 
       allKeys = Array(letterKeys.joined()) + Array(symbolKeys.joined())
     } else {
       if userDefaults.bool(forKey: "svAccentCharacters") {
-        letterKeys = SwedishKeyboardConstants.letterKeysPadDisableAccents
+        letterKeys = SwedishKeyboardProvider.genPadDisableAccentsLetterKeys()
       } else {
-        letterKeys = SwedishKeyboardConstants.letterKeysPad
+        letterKeys = SwedishKeyboardProvider.genPadLetterKeys()
       }
-      numberKeys = SwedishKeyboardConstants.numberKeysPad
-      symbolKeys = SwedishKeyboardConstants.symbolKeysPad
+      numberKeys = SwedishKeyboardProvider.genPadNumberKeys(currencyKey: currencyKey)
+      symbolKeys = SwedishKeyboardProvider.genPadSymbolKeys(currencyKeys: currencyKeys)
 
       letterKeys.removeFirst(1)
 

--- a/Scribe.xcodeproj/project.pbxproj
+++ b/Scribe.xcodeproj/project.pbxproj
@@ -22,6 +22,18 @@
 		147797C02A2D0CDF0044A53E /* SettingsTableData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147797BF2A2D0CDF0044A53E /* SettingsTableData.swift */; };
 		14AC56842A24AED3006B1DDF /* AboutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AC56832A24AED3006B1DDF /* AboutViewController.swift */; };
 		14AC568A2A261663006B1DDF /* InformationScreenVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AC56892A261663006B1DDF /* InformationScreenVC.swift */; };
+		19DC85FA2C7772FC006E32FD /* KeyboardBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */; };
+		19DC85FB2C7772FC006E32FD /* KeyboardBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */; };
+		19DC85FC2C7772FC006E32FD /* KeyboardBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */; };
+		19DC85FD2C7772FC006E32FD /* KeyboardBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */; };
+		19DC85FE2C7772FC006E32FD /* KeyboardBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */; };
+		19DC85FF2C7772FC006E32FD /* KeyboardBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */; };
+		19DC86002C7772FC006E32FD /* KeyboardBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */; };
+		19DC86012C7772FC006E32FD /* KeyboardBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */; };
+		19DC86022C7772FC006E32FD /* KeyboardBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */; };
+		19DC86032C7772FC006E32FD /* KeyboardBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */; };
+		19DC86042C7772FC006E32FD /* KeyboardBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */; };
+		19DC86052C7772FC006E32FD /* KeyboardBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */; };
 		30453951293B9106003AE55B /* InstallScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2DCB027AD37BD0057A10D /* InstallScreen.swift */; };
 		30453953293B9107003AE55B /* InstallScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2DCB027AD37BD0057A10D /* InstallScreen.swift */; };
 		30453954293B9107003AE55B /* InstallScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2DCB027AD37BD0057A10D /* InstallScreen.swift */; };
@@ -871,6 +883,7 @@
 		147797BF2A2D0CDF0044A53E /* SettingsTableData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableData.swift; sourceTree = "<group>"; };
 		14AC56832A24AED3006B1DDF /* AboutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutViewController.swift; sourceTree = "<group>"; };
 		14AC56892A261663006B1DDF /* InformationScreenVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationScreenVC.swift; sourceTree = "<group>"; };
+		19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardBuilder.swift; sourceTree = "<group>"; };
 		30453963293B9D18003AE55B /* InformationToolTipData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationToolTipData.swift; sourceTree = "<group>"; };
 		30453966293B9D31003AE55B /* ViewThemeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewThemeable.swift; sourceTree = "<group>"; };
 		30453968293B9DB4003AE55B /* ToolTipViewUpdatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolTipViewUpdatable.swift; sourceTree = "<group>"; };
@@ -1499,6 +1512,7 @@
 				D190B2452741B1FE00705659 /* KeyboardsBase */,
 				D1CCA15B2742B9F700902744 /* LanguageKeyboards */,
 				EDC364682AE408F20001E456 /* InterfaceConstants.swift */,
+				19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */,
 			);
 			path = Keyboards;
 			sourceTree = "<group>";
@@ -2075,6 +2089,7 @@
 				D171943827AEF0560038660B /* KeyboardStyling.swift in Sources */,
 				1455C87C2BD0EE4200F12BD4 /* DownloadDataTable.swift in Sources */,
 				D111E9BA27AFE7B200746F92 /* Annotate.swift in Sources */,
+				19DC85FA2C7772FC006E32FD /* KeyboardBuilder.swift in Sources */,
 				CE1378CC28F5D7AC00E1CBC2 /* UIColor+ScribeColors.swift in Sources */,
 				D17193F027AECB350038660B /* SVInterfaceVariables.swift in Sources */,
 				D1CDED792A859FB600098546 /* ENCommandVariables.swift in Sources */,
@@ -2156,6 +2171,7 @@
 				30453984293B9E12003AE55B /* InformationToolTipData.swift in Sources */,
 				D111E9B427AFE79500746F92 /* Translate.swift in Sources */,
 				D17193E227AECAA60038660B /* RUInterfaceVariables.swift in Sources */,
+				19DC85FE2C7772FC006E32FD /* KeyboardBuilder.swift in Sources */,
 				D190B2472741B24F00705659 /* CommandVariables.swift in Sources */,
 				D16DD3AA29E78A1500FB9022 /* Utilities.swift in Sources */,
 				D171941227AECCF50038660B /* RUCommandVariables.swift in Sources */,
@@ -2216,6 +2232,7 @@
 				D111E9B327AFE79500746F92 /* Translate.swift in Sources */,
 				D171940127AECCD10038660B /* DECommandVariables.swift in Sources */,
 				D171940927AECCE50038660B /* PTCommandVariables.swift in Sources */,
+				19DC85FD2C7772FC006E32FD /* KeyboardBuilder.swift in Sources */,
 				D16DD3A829E78A1500FB9022 /* Utilities.swift in Sources */,
 				D17193D927AECA450038660B /* PTInterfaceVariables.swift in Sources */,
 				D111E9BB27AFE7B200746F92 /* Annotate.swift in Sources */,
@@ -2276,6 +2293,7 @@
 				30453986293B9E13003AE55B /* InformationToolTipData.swift in Sources */,
 				D111E9B527AFE79500746F92 /* Translate.swift in Sources */,
 				D171940327AECCD10038660B /* DECommandVariables.swift in Sources */,
+				19DC86022C7772FC006E32FD /* KeyboardBuilder.swift in Sources */,
 				D171940B27AECCE50038660B /* PTCommandVariables.swift in Sources */,
 				D16DD3AE29E78A1500FB9022 /* Utilities.swift in Sources */,
 				D17193DB27AECA450038660B /* PTInterfaceVariables.swift in Sources */,
@@ -2336,6 +2354,7 @@
 				30453981293B9E11003AE55B /* InformationToolTipData.swift in Sources */,
 				D111E9B727AFE79500746F92 /* Translate.swift in Sources */,
 				D171940527AECCD10038660B /* DECommandVariables.swift in Sources */,
+				19DC86042C7772FC006E32FD /* KeyboardBuilder.swift in Sources */,
 				D171940D27AECCE50038660B /* PTCommandVariables.swift in Sources */,
 				D16DD3B029E78A1500FB9022 /* Utilities.swift in Sources */,
 				D17193DD27AECA450038660B /* PTInterfaceVariables.swift in Sources */,
@@ -2396,6 +2415,7 @@
 				30453987293B9E13003AE55B /* InformationToolTipData.swift in Sources */,
 				D111E9B627AFE79500746F92 /* Translate.swift in Sources */,
 				D171940427AECCD10038660B /* DECommandVariables.swift in Sources */,
+				19DC86032C7772FC006E32FD /* KeyboardBuilder.swift in Sources */,
 				D171940C27AECCE50038660B /* PTCommandVariables.swift in Sources */,
 				D16DD3AF29E78A1500FB9022 /* Utilities.swift in Sources */,
 				D17193DC27AECA450038660B /* PTInterfaceVariables.swift in Sources */,
@@ -2456,6 +2476,7 @@
 				30453980293B9E10003AE55B /* InformationToolTipData.swift in Sources */,
 				D111E9B827AFE79500746F92 /* Translate.swift in Sources */,
 				D171940627AECCD10038660B /* DECommandVariables.swift in Sources */,
+				19DC86052C7772FC006E32FD /* KeyboardBuilder.swift in Sources */,
 				D171940E27AECCE50038660B /* PTCommandVariables.swift in Sources */,
 				D16DD3B129E78A1500FB9022 /* Utilities.swift in Sources */,
 				D17193DE27AECA450038660B /* PTInterfaceVariables.swift in Sources */,
@@ -2516,6 +2537,7 @@
 				D1AB5B3E29C757A100CCB0C1 /* InformationToolTipData.swift in Sources */,
 				D16D975429C75A4900E33F86 /* NBKeyboardViewController.swift in Sources */,
 				D1AB5B3F29C757A100CCB0C1 /* LanguageDBManager.swift in Sources */,
+				19DC86012C7772FC006E32FD /* KeyboardBuilder.swift in Sources */,
 				D1AB5B4029C757A100CCB0C1 /* CommandVariables.swift in Sources */,
 				D16DD3AD29E78A1500FB9022 /* Utilities.swift in Sources */,
 				D1AB5B4129C757A100CCB0C1 /* Translate.swift in Sources */,
@@ -2576,6 +2598,7 @@
 				D1AFDF1B29CA66D00033BF27 /* Annotate.swift in Sources */,
 				D1AFDF1C29CA66D00033BF27 /* InformationToolTipData.swift in Sources */,
 				D1AFDF1D29CA66D00033BF27 /* LanguageDBManager.swift in Sources */,
+				19DC85FC2C7772FC006E32FD /* KeyboardBuilder.swift in Sources */,
 				D1AFDF1E29CA66D00033BF27 /* CommandVariables.swift in Sources */,
 				D16DD3A729E78A1500FB9022 /* Utilities.swift in Sources */,
 				D1AFDF1F29CA66D00033BF27 /* Translate.swift in Sources */,
@@ -2636,6 +2659,7 @@
 				D1AFDF9929CA66F40033BF27 /* InformationToolTipData.swift in Sources */,
 				D1AFDFBC29CA67EE0033BF27 /* DAKeyboardViewController.swift in Sources */,
 				D1AFDF9A29CA66F40033BF27 /* LanguageDBManager.swift in Sources */,
+				19DC85FB2C7772FC006E32FD /* KeyboardBuilder.swift in Sources */,
 				D1AFDF9B29CA66F40033BF27 /* CommandVariables.swift in Sources */,
 				D16DD3A629E78A1500FB9022 /* Utilities.swift in Sources */,
 				D1AFDF9C29CA66F40033BF27 /* Translate.swift in Sources */,
@@ -2696,6 +2720,7 @@
 				D1AFDFEF29CA6E900033BF27 /* InformationToolTipData.swift in Sources */,
 				D1AFDFF029CA6E900033BF27 /* LanguageDBManager.swift in Sources */,
 				D1AFDFF129CA6E900033BF27 /* CommandVariables.swift in Sources */,
+				19DC85FF2C7772FC006E32FD /* KeyboardBuilder.swift in Sources */,
 				D1AFE01229CA6F360033BF27 /* HEKeyboardViewController.swift in Sources */,
 				D16DD3AB29E78A1500FB9022 /* Utilities.swift in Sources */,
 				D1AFDFF229CA6E900033BF27 /* Translate.swift in Sources */,
@@ -2756,6 +2781,7 @@
 				30453985293B9E12003AE55B /* InformationToolTipData.swift in Sources */,
 				D1B81D4027BBB70C0085FE5E /* LanguageDBManager.swift in Sources */,
 				D1B81D4227BBB71C0085FE5E /* CommandVariables.swift in Sources */,
+				19DC86002C7772FC006E32FD /* KeyboardBuilder.swift in Sources */,
 				D1B81D4727BBB71C0085FE5E /* Translate.swift in Sources */,
 				D16DD3AC29E78A1500FB9022 /* Utilities.swift in Sources */,
 				D1B81D3A27BBB6F90085FE5E /* ColorVariables.swift in Sources */,

--- a/Scribe.xcodeproj/project.pbxproj
+++ b/Scribe.xcodeproj/project.pbxproj
@@ -22,6 +22,18 @@
 		147797C02A2D0CDF0044A53E /* SettingsTableData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147797BF2A2D0CDF0044A53E /* SettingsTableData.swift */; };
 		14AC56842A24AED3006B1DDF /* AboutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AC56832A24AED3006B1DDF /* AboutViewController.swift */; };
 		14AC568A2A261663006B1DDF /* InformationScreenVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14AC56892A261663006B1DDF /* InformationScreenVC.swift */; };
+		198369CC2C7980BA00C1B583 /* KeyboardProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198369CB2C7980BA00C1B583 /* KeyboardProvider.swift */; };
+		198369CD2C7980BA00C1B583 /* KeyboardProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198369CB2C7980BA00C1B583 /* KeyboardProvider.swift */; };
+		198369CE2C7980BA00C1B583 /* KeyboardProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198369CB2C7980BA00C1B583 /* KeyboardProvider.swift */; };
+		198369CF2C7980BA00C1B583 /* KeyboardProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198369CB2C7980BA00C1B583 /* KeyboardProvider.swift */; };
+		198369D02C7980BA00C1B583 /* KeyboardProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198369CB2C7980BA00C1B583 /* KeyboardProvider.swift */; };
+		198369D12C7980BA00C1B583 /* KeyboardProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198369CB2C7980BA00C1B583 /* KeyboardProvider.swift */; };
+		198369D22C7980BA00C1B583 /* KeyboardProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198369CB2C7980BA00C1B583 /* KeyboardProvider.swift */; };
+		198369D32C7980BA00C1B583 /* KeyboardProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198369CB2C7980BA00C1B583 /* KeyboardProvider.swift */; };
+		198369D42C7980BA00C1B583 /* KeyboardProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198369CB2C7980BA00C1B583 /* KeyboardProvider.swift */; };
+		198369D52C7980BA00C1B583 /* KeyboardProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198369CB2C7980BA00C1B583 /* KeyboardProvider.swift */; };
+		198369D62C7980BA00C1B583 /* KeyboardProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198369CB2C7980BA00C1B583 /* KeyboardProvider.swift */; };
+		198369D72C7980BA00C1B583 /* KeyboardProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198369CB2C7980BA00C1B583 /* KeyboardProvider.swift */; };
 		19DC85FA2C7772FC006E32FD /* KeyboardBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */; };
 		19DC85FB2C7772FC006E32FD /* KeyboardBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */; };
 		19DC85FC2C7772FC006E32FD /* KeyboardBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */; };
@@ -883,6 +895,7 @@
 		147797BF2A2D0CDF0044A53E /* SettingsTableData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableData.swift; sourceTree = "<group>"; };
 		14AC56832A24AED3006B1DDF /* AboutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutViewController.swift; sourceTree = "<group>"; };
 		14AC56892A261663006B1DDF /* InformationScreenVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationScreenVC.swift; sourceTree = "<group>"; };
+		198369CB2C7980BA00C1B583 /* KeyboardProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardProvider.swift; sourceTree = "<group>"; };
 		19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardBuilder.swift; sourceTree = "<group>"; };
 		30453963293B9D18003AE55B /* InformationToolTipData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationToolTipData.swift; sourceTree = "<group>"; };
 		30453966293B9D31003AE55B /* ViewThemeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewThemeable.swift; sourceTree = "<group>"; };
@@ -1513,6 +1526,7 @@
 				D1CCA15B2742B9F700902744 /* LanguageKeyboards */,
 				EDC364682AE408F20001E456 /* InterfaceConstants.swift */,
 				19DC85F92C7772FC006E32FD /* KeyboardBuilder.swift */,
+				198369CB2C7980BA00C1B583 /* KeyboardProvider.swift */,
 			);
 			path = Keyboards;
 			sourceTree = "<group>";
@@ -2090,6 +2104,7 @@
 				1455C87C2BD0EE4200F12BD4 /* DownloadDataTable.swift in Sources */,
 				D111E9BA27AFE7B200746F92 /* Annotate.swift in Sources */,
 				19DC85FA2C7772FC006E32FD /* KeyboardBuilder.swift in Sources */,
+				198369CC2C7980BA00C1B583 /* KeyboardProvider.swift in Sources */,
 				CE1378CC28F5D7AC00E1CBC2 /* UIColor+ScribeColors.swift in Sources */,
 				D17193F027AECB350038660B /* SVInterfaceVariables.swift in Sources */,
 				D1CDED792A859FB600098546 /* ENCommandVariables.swift in Sources */,
@@ -2167,6 +2182,7 @@
 				D171946727AF31770038660B /* Conjugate.swift in Sources */,
 				D111E9AC27AFE78600746F92 /* Plural.swift in Sources */,
 				D190B242274056D400705659 /* ColorVariables.swift in Sources */,
+				198369D02C7980BA00C1B583 /* KeyboardProvider.swift in Sources */,
 				D17193EA27AECAE60038660B /* ESInterfaceVariables.swift in Sources */,
 				30453984293B9E12003AE55B /* InformationToolTipData.swift in Sources */,
 				D111E9B427AFE79500746F92 /* Translate.swift in Sources */,
@@ -2228,6 +2244,7 @@
 				D111E9AB27AFE78600746F92 /* Plural.swift in Sources */,
 				D109A237275B6A99005E2271 /* LanguageDBManager.swift in Sources */,
 				D109A228275B6A8B005E2271 /* Extensions.swift in Sources */,
+				198369CF2C7980BA00C1B583 /* KeyboardProvider.swift in Sources */,
 				30453982293B9E11003AE55B /* InformationToolTipData.swift in Sources */,
 				D111E9B327AFE79500746F92 /* Translate.swift in Sources */,
 				D171940127AECCD10038660B /* DECommandVariables.swift in Sources */,
@@ -2289,6 +2306,7 @@
 				D171946827AF31770038660B /* Conjugate.swift in Sources */,
 				D111E9AD27AFE78600746F92 /* Plural.swift in Sources */,
 				D109A22E275B6A8C005E2271 /* Extensions.swift in Sources */,
+				198369D42C7980BA00C1B583 /* KeyboardProvider.swift in Sources */,
 				D109A22D275B6A8C005E2271 /* KeyboardViewController.swift in Sources */,
 				30453986293B9E13003AE55B /* InformationToolTipData.swift in Sources */,
 				D111E9B527AFE79500746F92 /* Translate.swift in Sources */,
@@ -2350,6 +2368,7 @@
 				D171946A27AF31770038660B /* Conjugate.swift in Sources */,
 				D111E9AF27AFE78600746F92 /* Plural.swift in Sources */,
 				D190B243274056D400705659 /* ColorVariables.swift in Sources */,
+				198369D62C7980BA00C1B583 /* KeyboardProvider.swift in Sources */,
 				D190B2482741B24F00705659 /* CommandVariables.swift in Sources */,
 				30453981293B9E11003AE55B /* InformationToolTipData.swift in Sources */,
 				D111E9B727AFE79500746F92 /* Translate.swift in Sources */,
@@ -2411,6 +2430,7 @@
 				D171946927AF31770038660B /* Conjugate.swift in Sources */,
 				D111E9AE27AFE78600746F92 /* Plural.swift in Sources */,
 				D1671A72275A1FC000A7C118 /* Extensions.swift in Sources */,
+				198369D52C7980BA00C1B583 /* KeyboardProvider.swift in Sources */,
 				D1671A73275A1FC000A7C118 /* InterfaceVariables.swift in Sources */,
 				30453987293B9E13003AE55B /* InformationToolTipData.swift in Sources */,
 				D111E9B627AFE79500746F92 /* Translate.swift in Sources */,
@@ -2472,6 +2492,7 @@
 				D171946B27AF31770038660B /* Conjugate.swift in Sources */,
 				D111E9B027AFE78600746F92 /* Plural.swift in Sources */,
 				D18EA8A92760D6F5001E1358 /* Extensions.swift in Sources */,
+				198369D72C7980BA00C1B583 /* KeyboardProvider.swift in Sources */,
 				D18EA89C2760D4A6001E1358 /* SVKeyboardViewController.swift in Sources */,
 				30453980293B9E10003AE55B /* InformationToolTipData.swift in Sources */,
 				D111E9B827AFE79500746F92 /* Translate.swift in Sources */,
@@ -2533,6 +2554,7 @@
 				D1AB5B3A29C757A100CCB0C1 /* Conjugate.swift in Sources */,
 				D1AB5B3B29C757A100CCB0C1 /* PTCommandVariables.swift in Sources */,
 				D1AB5B3C29C757A100CCB0C1 /* DEInterfaceVariables.swift in Sources */,
+				198369D32C7980BA00C1B583 /* KeyboardProvider.swift in Sources */,
 				D1AB5B3D29C757A100CCB0C1 /* Annotate.swift in Sources */,
 				D1AB5B3E29C757A100CCB0C1 /* InformationToolTipData.swift in Sources */,
 				D16D975429C75A4900E33F86 /* NBKeyboardViewController.swift in Sources */,
@@ -2594,6 +2616,7 @@
 				D1AFDF1829CA66D00033BF27 /* Conjugate.swift in Sources */,
 				D1AFDF1929CA66D00033BF27 /* PTCommandVariables.swift in Sources */,
 				D1AFDF1A29CA66D00033BF27 /* DEInterfaceVariables.swift in Sources */,
+				198369CE2C7980BA00C1B583 /* KeyboardProvider.swift in Sources */,
 				D1AFDFBD29CA67F10033BF27 /* ENKeyboardViewController.swift in Sources */,
 				D1AFDF1B29CA66D00033BF27 /* Annotate.swift in Sources */,
 				D1AFDF1C29CA66D00033BF27 /* InformationToolTipData.swift in Sources */,
@@ -2655,6 +2678,7 @@
 				D1AFDF9529CA66F40033BF27 /* Conjugate.swift in Sources */,
 				D1AFDF9629CA66F40033BF27 /* PTCommandVariables.swift in Sources */,
 				D1AFDF9729CA66F40033BF27 /* DEInterfaceVariables.swift in Sources */,
+				198369CD2C7980BA00C1B583 /* KeyboardProvider.swift in Sources */,
 				D1AFDF9829CA66F40033BF27 /* Annotate.swift in Sources */,
 				D1AFDF9929CA66F40033BF27 /* InformationToolTipData.swift in Sources */,
 				D1AFDFBC29CA67EE0033BF27 /* DAKeyboardViewController.swift in Sources */,
@@ -2716,6 +2740,7 @@
 				D1AFDFEB29CA6E900033BF27 /* Conjugate.swift in Sources */,
 				D1AFDFEC29CA6E900033BF27 /* PTCommandVariables.swift in Sources */,
 				D1AFDFED29CA6E900033BF27 /* DEInterfaceVariables.swift in Sources */,
+				198369D12C7980BA00C1B583 /* KeyboardProvider.swift in Sources */,
 				D1AFDFEE29CA6E900033BF27 /* Annotate.swift in Sources */,
 				D1AFDFEF29CA6E900033BF27 /* InformationToolTipData.swift in Sources */,
 				D1AFDFF029CA6E900033BF27 /* LanguageDBManager.swift in Sources */,
@@ -2777,6 +2802,7 @@
 				D1B81D4527BBB71C0085FE5E /* Conjugate.swift in Sources */,
 				D1B81D2E27BBB69B0085FE5E /* PTCommandVariables.swift in Sources */,
 				D1B81D2B27BBB6830085FE5E /* DEInterfaceVariables.swift in Sources */,
+				198369D22C7980BA00C1B583 /* KeyboardProvider.swift in Sources */,
 				D1B81D4327BBB71C0085FE5E /* Annotate.swift in Sources */,
 				30453985293B9E12003AE55B /* InformationToolTipData.swift in Sources */,
 				D1B81D4027BBB70C0085FE5E /* LanguageDBManager.swift in Sources */,


### PR DESCRIPTION
the iPhone keyboard could be replaced with difference currency symbols

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
In this task, modify the keyboard generation from static to dynamic using the builder pattern which allows the keyboard to replace currency symbols (also can replace other symbols).

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue
* #238 
<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

