### PR TITLE
Flip install screen corner for RTL languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 
 - All orphaned documentation comments have been removed from the codebase ([#425](https://github.com/scribe-org/Scribe-iOS/issues/425)).
 - All if clauses within for loops have been removed from the codebase ([#428](https://github.com/scribe-org/Scribe-iOS/issues/428)).
+- The app interface was refactored to allow for right to left languages for the app texts ([#513](https://github.com/scribe-org/Scribe-iOS/issues/513)).
 
 # Scribe-iOS 3.1.1
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,6 @@
 
 <a href='https://apps.apple.com/app/scribe-language-keyboards/id1596613886'><img alt='Available on the App Store' src='https://raw.githubusercontent.com/scribe-org/Scribe-iOS/main/.github/resources/images/app_store_badge.png' height='60px'/></a>
 
-<details><summary>🌐 Language</summary>
-<p>
-
-- [Open a localization issue](https://github.com/scribe-org/Scribe-iOS/issues/new?assignees=&labels=localization&template=localization.yml) to add a new readme to the [README](https://github.com/scribe-org/Scribe-iOS/tree/main/README) directory
-
-</p>
-</details>
-
 ## iOS app with keyboards for language learners
 
 **Scribe-iOS** is a pack of iOS and iPadOS keyboards for language learners. Features include translation **`(beta)`**, verb conjugation and word annotation that give users the tools needed to communicate with confidence.

--- a/Scribe/AboutTab/AboutTableData.swift
+++ b/Scribe/AboutTab/AboutTableData.swift
@@ -91,7 +91,7 @@ struct AboutTableData {
           externalLink: true
         ),
         Section(
-          sectionTitle: NSLocalizedString("app.about.feedback.appHints", value: "Reset app hints", comment: ""),
+          sectionTitle: NSLocalizedString("app.about.feedback.app_hints", value: "Reset app hints", comment: ""),
           imageString: "lightbulb.max",
           hasNestedNavigation: true,
           sectionState: .appHints

--- a/Scribe/AppTexts/AppTextStyling.swift
+++ b/Scribe/AppTexts/AppTextStyling.swift
@@ -19,6 +19,8 @@
 
 import UIKit
 
+let preferredLanguage = Locale.preferredLanguages[0]
+
 var fontSize = CGFloat(0)
 
 /// Concatenates attributed strings.

--- a/Scribe/AppTexts/InstallScreen.swift
+++ b/Scribe/AppTexts/InstallScreen.swift
@@ -19,11 +19,16 @@
 
 import UIKit
 
+let firstLineNumber = preferredLanguage.prefix(2) == "ar" ? "١. " : "1. "
+let secondLineNumber = preferredLanguage.prefix(2) == "ar" ? "\n\n٢. " : "\n\n2. "
+let thirdLineNumber = preferredLanguage.prefix(2) == "ar" ? "\n\n٣. " : "\n\n3. "
+let fourthLineNumber = preferredLanguage.prefix(2) == "ar" ? "\n\n٤. " : "\n\n4. "
+
 /// Formats and returns the directions of the installation guidelines.
 func getInstallationDirections(fontSize: CGFloat) -> NSMutableAttributedString {
   let globeString = getGlobeIcon(fontSize: fontSize)
 
-  let startOfBody = NSMutableAttributedString(string: "1. ", attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: fontSize)])
+  let startOfBody = NSMutableAttributedString(string: firstLineNumber, attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: fontSize)])
 
   var settingsLink = NSMutableAttributedString()
   let linkText = NSLocalizedString("app.installation.keyboard.scribe_settings", value: "Open Scribe settings", comment: "")
@@ -35,13 +40,13 @@ func getInstallationDirections(fontSize: CGFloat) -> NSMutableAttributedString {
 
   let installStart = concatAttributedStrings(left: startOfBody, right: settingsLink)
 
-  let installDirections = NSMutableAttributedString(string: "\n\n2. " + NSLocalizedString("app.installation.keyboard.text_1", value: "Select", comment: "") + " ", attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: fontSize)])
+  let installDirections = NSMutableAttributedString(string: secondLineNumber + NSLocalizedString("app.installation.keyboard.text_1", value: "Select", comment: "") + " ", attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: fontSize)])
 
   let boldText = NSMutableAttributedString(string: NSLocalizedString("app.installation.keyboard.keyboards_bold", value: "Keyboards", comment: ""), attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: fontSize)])
   boldText.addAttribute(NSAttributedString.Key.font, value: UIFont.boldSystemFont(ofSize: fontSize), range: NSRange(location: 0, length: boldText.length))
   installDirections.append(boldText)
-
-  installDirections.append(NSMutableAttributedString(string: "\n\n3. " + NSLocalizedString("app.installation.keyboard.text_2", value: "Activate keyboards that you want to use", comment: "") + "\n\n4. " + NSLocalizedString("app.installation.keyboard.text_3", value: "When typing, press", comment: "") + " ", attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: fontSize)]))
+  
+  installDirections.append(NSMutableAttributedString(string: thirdLineNumber + NSLocalizedString("app.installation.keyboard.text_2", value: "Activate keyboards that you want to use", comment: "") + fourthLineNumber + NSLocalizedString("app.installation.keyboard.text_3", value: "When typing, press", comment: "") + " ", attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: fontSize)]))
 
   installDirections.append(globeString)
 

--- a/Scribe/AppTexts/InstallScreen.swift
+++ b/Scribe/AppTexts/InstallScreen.swift
@@ -45,7 +45,7 @@ func getInstallationDirections(fontSize: CGFloat) -> NSMutableAttributedString {
   let boldText = NSMutableAttributedString(string: NSLocalizedString("app.installation.keyboard.keyboards_bold", value: "Keyboards", comment: ""), attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: fontSize)])
   boldText.addAttribute(NSAttributedString.Key.font, value: UIFont.boldSystemFont(ofSize: fontSize), range: NSRange(location: 0, length: boldText.length))
   installDirections.append(boldText)
-  
+
   installDirections.append(NSMutableAttributedString(string: thirdLineNumber + NSLocalizedString("app.installation.keyboard.text_2", value: "Activate keyboards that you want to use", comment: "") + fourthLineNumber + NSLocalizedString("app.installation.keyboard.text_3", value: "When typing, press", comment: "") + " ", attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: fontSize)]))
 
   installDirections.append(globeString)

--- a/Scribe/Base.lproj/AppScreen.storyboard
+++ b/Scribe/Base.lproj/AppScreen.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="z4h-ME-igh">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="z4h-ME-igh">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -133,7 +133,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="316.33333333333331"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="none" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hsr-GS-NQS" userLabel="HeadingLabelPhone">
-                                                <rect key="frame" x="15.000000000000004" y="20" width="44.333333333333343" height="21"/>
+                                                <rect key="frame" x="15" y="20" width="345" height="21"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="21" id="UI5-ex-Fun"/>
                                                 </constraints>
@@ -181,7 +181,7 @@
                                             <constraint firstItem="61J-Jd-qbi" firstAttribute="leading" secondItem="XYp-UM-US6" secondAttribute="leading" constant="15" id="KJR-dY-kza"/>
                                             <constraint firstAttribute="bottom" secondItem="61J-Jd-qbi" secondAttribute="bottom" constant="8" id="Vyt-QG-c4M"/>
                                             <constraint firstItem="61J-Jd-qbi" firstAttribute="top" secondItem="Hsr-GS-NQS" secondAttribute="bottom" constant="4" id="feV-zw-mjH"/>
-                                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Hsr-GS-NQS" secondAttribute="trailing" constant="20" symbolic="YES" id="g1Q-zd-LHB"/>
+                                            <constraint firstAttribute="trailing" secondItem="Hsr-GS-NQS" secondAttribute="trailing" constant="15" id="g1Q-zd-LHB"/>
                                             <constraint firstItem="Hsr-GS-NQS" firstAttribute="top" secondItem="XYp-UM-US6" secondAttribute="top" constant="20" symbolic="YES" id="uJN-FA-Nt5"/>
                                         </constraints>
                                     </view>
@@ -348,7 +348,7 @@
                                 <color key="backgroundColor" systemColor="systemBrownColor"/>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jrH-BQ-4ti" userLabel="InstallationLabel">
-                                <rect key="frame" x="15.000000000000004" y="219.66666666666666" width="44.333333333333343" height="20.333333333333343"/>
+                                <rect key="frame" x="15" y="219.66666666666666" width="345" height="20.333333333333343"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -472,7 +472,7 @@
                             <constraint firstItem="Oxz-Zq-2g7" firstAttribute="top" secondItem="eyk-EK-raM" secondAttribute="bottom" id="vNz-Be-acs"/>
                             <constraint firstItem="xOG-9z-mVQ" firstAttribute="height" secondItem="6Tk-OE-BBY" secondAttribute="height" multiplier="0.05" id="xhQ-Iw-ZFa"/>
                             <constraint firstItem="Oxz-Zq-2g7" firstAttribute="height" secondItem="6Tk-OE-BBY" secondAttribute="height" multiplier="0.15" id="yJI-k4-sar"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="jrH-BQ-4ti" secondAttribute="trailing" symbolic="YES" id="zOe-dD-pB6"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="jrH-BQ-4ti" secondAttribute="trailing" constant="15" id="zOe-dD-pB6"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Installation" image="keyboard" catalog="system" id="HNz-5D-1T0"/>
@@ -611,7 +611,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBrownColor">
-            <color red="0.63529411764705879" green="0.51764705882352946" blue="0.36862745098039218" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.63529411759999999" green="0.51764705879999995" blue="0.36862745099999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Scribe/InstallationTab/InstallationVC.swift
+++ b/Scribe/InstallationTab/InstallationVC.swift
@@ -166,7 +166,13 @@ class InstallationVC: UIViewController {
 
   /// Sets properties for the app screen given the current device.
   func setUIDeviceProperties() {
-    settingsCorner.layer.maskedCorners = .layerMaxXMinYCorner
+    // Flips coloured corner with settings icon based on orientation of text.
+    settingsCorner.image = settingsCorner.image?.imageFlippedForRightToLeftLayoutDirection()
+    if UIView.userInterfaceLayoutDirection(for: appTextView.semanticContentAttribute) == .rightToLeft {
+      settingsCorner.layer.maskedCorners = .layerMinXMinYCorner // "top-left"
+    } else {
+      settingsCorner.layer.maskedCorners = .layerMaxXMinYCorner // "top-right"
+    }
     settingsCorner.layer.cornerRadius = DeviceType.isPad ? appTextBackground.frame.width * 0.02 : appTextBackground.frame.width * 0.05
 
     settingsBtn.setTitle("", for: .normal)

--- a/Scribe/SettingsTab/SettingsViewController.swift
+++ b/Scribe/SettingsTab/SettingsViewController.swift
@@ -229,7 +229,14 @@ extension SettingsViewController: UITableViewDelegate {
       headerView = UIView(frame: CGRect(x: 0, y: 0, width: parentTable.bounds.width, height: 32))
     }
 
-    let label = UILabel(frame: CGRect(x: 0, y: 0, width: headerView.bounds.width, height: 32))
+    let label = UILabel(
+      frame: CGRect(
+        x: preferredLanguage.prefix(2) == "ar" ? -1 * headerView.bounds.width / 10: 0,
+        y: 0,
+        width: headerView.bounds.width,
+        height: 32
+      )
+    )
 
     label.text = tableData[section].headingTitle
     label.font = UIFont.boldSystemFont(ofSize: fontSize * 1.1)

--- a/Scribe/Views/Cells/InfoChildTableViewCell/InfoChildTableViewCell.swift
+++ b/Scribe/Views/Cells/InfoChildTableViewCell/InfoChildTableViewCell.swift
@@ -121,7 +121,9 @@ final class InfoChildTableViewCell: UITableViewCell {
       toggleSwitch.onTintColor = .init(ScribeColor.scribeCTA).withAlphaComponent(0.4)
       toggleSwitch.thumbTintColor = toggleSwitch.isOn ? .init(.scribeCTA) : .lightGray
     } else {
-      iconImageView.image = UIImage(systemName: "chevron.right")
+      iconImageView.image = UIImage(
+        systemName: preferredLanguage.prefix(2) == "ar" ? "chevron.left": "chevron.right"
+      )
       iconImageView.tintColor = menuOptionColor
       toggleSwitch.isHidden = true
     }

--- a/Scribe/Views/Cells/UITableViewCells/AboutTableViewCell.swift
+++ b/Scribe/Views/Cells/UITableViewCells/AboutTableViewCell.swift
@@ -87,7 +87,9 @@ final class AboutTableViewCell: UITableViewCell {
 
     if section.hasNestedNavigation {
       let resetIcon = UIImage(systemName: "arrow.circlepath")
-      let disclosureIcon = UIImage(systemName: "chevron.right")
+      let disclosureIcon = UIImage(
+        systemName: preferredLanguage.prefix(2) == "ar" ? "chevron.left": "chevron.right"
+      )
       let rightIcon = section.sectionState == .appHints ? resetIcon : disclosureIcon
       let accessory  = UIImageView(
         frame: CGRect(

--- a/Scribe/i18n/.github/workflows/pr_maintainer_checklist.yaml
+++ b/Scribe/i18n/.github/workflows/pr_maintainer_checklist.yaml
@@ -37,4 +37,3 @@ jobs:
             - [ ] The commit messages for the remote branch should be checked to make sure the contributor's email is set up correctly so that they receive credit for their contribution
               - The contributor's name and icon in remote commits should be the same as what appears in the PR
               - If there's a mismatch, the contributor needs to make sure that the [email they use for GitHub](https://github.com/settings/emails) matches what they have for `git config user.email` in their local activist repo
-          

--- a/Scribe/i18n/Scribe-i18n/Localizable.xcstrings
+++ b/Scribe/i18n/Scribe-i18n/Localizable.xcstrings
@@ -1369,7 +1369,6 @@
     },
     "app.about.feedback.app_hints" : {
       "comment" : "",
-      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -1429,17 +1428,6 @@
           "stringUnit" : {
             "state" : "",
             "value" : "Återställ app-tips"
-          }
-        }
-      }
-    },
-    "app.about.feedback.appHints" : {
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reset app hints"
           }
         }
       }


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `xcodebuild` and `swiftlint --strict` commands as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-iOS/blob/main/CONTRIBUTING.md#testing)

---

### Description

The yellow corner on the installation screen now flips based on the orientation of the user's app language. The orientation for LTR languages stays the same.

<img width="337" alt="image" src="https://github.com/user-attachments/assets/ef830254-604b-4fe3-a5b6-46dbb23fddcc"> <img width="331" alt="image" src="https://github.com/user-attachments/assets/53c793da-885a-4938-b328-ff168a831adb">


### Related issue

- #513
