### PR TITLE
Add plural and translate tests for simple queries

### DIFF
--- a/Tests/Keyboards/KeyboardsBase/TestQuery.swift
+++ b/Tests/Keyboards/KeyboardsBase/TestQuery.swift
@@ -1,0 +1,111 @@
+/**
+ * TestQuery.swift
+ *
+ * Copyright (C) 2024 Scribe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import XCTest
+@testable import Scribe
+
+final class ScribeFunctionalityTests: XCTestCase {
+    
+    func testQueryPlural_EmptyInput() {
+        // Mock UILabel
+        let commandBar = UILabel()
+        commandBar.text = ""
+        
+        // Call the function
+        queryPlural(commandBar: commandBar)
+        
+        // Assert: No text inserted, proxy state unchanged
+        XCTAssertEqual(proxy.text, "")
+        XCTAssertEqual(commandState, .default) // Assuming .default is the initial state
+    }
+    
+    func testQueryPlural_TypicalNoun() {
+        // Mock UILabel
+        let commandBar = UILabel()
+        commandBar.text = "plural:cat"
+        
+        // Call the function
+        queryPlural(commandBar: commandBar)
+        
+        // Assert: Correct plural inserted
+        XCTAssertEqual(proxy.text, "cats ") // Assuming a space is added
+    }
+    
+    func testQueryPlural_AlreadyPlural() {
+        // Mock UILabel
+        let commandBar = UILabel()
+        commandBar.text = "plural:cats"
+        
+        // Call the function
+        queryPlural(commandBar: commandBar)
+        
+        // Assert: Input recognized as already plural
+        XCTAssertEqual(proxy.text, "cats ") // Output matches input
+        XCTAssertEqual(commandState, .alreadyPlural)
+    }
+    
+    func testQueryPlural_CapitalizedNoun() {
+        // Mock UILabel
+        let commandBar = UILabel()
+        commandBar.text = "plural:Dog"
+        
+        // Call the function
+        queryPlural(commandBar: commandBar)
+        
+        // Assert: Capitalization preserved in plural
+        XCTAssertEqual(proxy.text, "Dogs ")
+    }
+    
+    func testQueryTranslation_EmptyInput() {
+        // Mock UILabel
+        let commandBar = UILabel()
+        commandBar.text = ""
+        
+        // Call the function
+        queryTranslation(commandBar: commandBar)
+        
+        // Assert: No text inserted, proxy state unchanged
+        XCTAssertEqual(proxy.text, "")
+        XCTAssertEqual(commandState, .default) // Assuming .default is the initial state
+    }
+    
+    func testQueryTranslation_ValidWord() {
+        // Mock UILabel
+        let commandBar = UILabel()
+        commandBar.text = "translate:hello"
+        
+        // Call the function
+        queryTranslation(commandBar: commandBar)
+        
+        // Assert: Correct translation inserted
+        XCTAssertEqual(proxy.text, "hola ") // Assuming 'hola' is the translation for 'hello'
+    }
+    
+    func testQueryTranslation_CapitalizedWord() {
+        // Mock UILabel
+        let commandBar = UILabel()
+        commandBar.text = "translate:Hello"
+        
+        // Call the function
+        queryTranslation(commandBar: commandBar)
+        
+        // Assert: Capitalization preserved in translation
+        XCTAssertEqual(proxy.text, "Hola ")
+    }
+}


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- x[] I have tested my code with the `xcodebuild` and `swiftlint --strict` commands as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-iOS/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
--> 
Introduces unit tests for the following functionalities:
- Pluralization Functionality (Plural.swift): Empty inputs, typical noun pluralization, recognition of already pluralized nouns, handling of capitalized nouns.
- Translation Functionality (Translate.swift): Empty inputs, translation of valid words, preservation of capitalization during translation.

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #ISSUE_NUMBER
