### PR TITLE
Fix: Adjust header padding to prevent letter clipping in RTL layouts.

### DIFF
--- a/Scribe/Views/BaseTableViewController.swift
+++ b/Scribe/Views/BaseTableViewController.swift
@@ -74,7 +74,7 @@ extension BaseTableViewController {
 
 extension BaseTableViewController {
   override func tableView(_: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-    headerView(for: section)
+    return headerView(for: section)
   }
 
   private func headerView(for section: Int) -> UIView? {
@@ -88,14 +88,45 @@ extension BaseTableViewController {
       )
     }
 
-    let label = UILabel(
-      frame: CGRect(x: 0, y: 0, width: headerView.bounds.width, height: sectionHeaderHeight)
-    )
+    let label = UILabel()
     label.text = dataSet[section].headingTitle
     label.font = UIFont.boldSystemFont(ofSize: fontSize * 1.1)
     label.textColor = keyCharColor
+    label.numberOfLines = 0
+    label.lineBreakMode = .byWordWrapping
+    label.adjustsFontSizeToFitWidth = true
+    label.minimumScaleFactor = 0.8
+    label.textAlignment = .natural
+
+    label.translatesAutoresizingMaskIntoConstraints = false
     headerView.addSubview(label)
 
+    let horizontalPadding: CGFloat = 8
+    let verticalPadding: CGFloat = 4
+
+    NSLayoutConstraint.activate([
+      label.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: horizontalPadding),
+      label.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: -horizontalPadding),
+      label.topAnchor.constraint(equalTo: headerView.topAnchor, constant: verticalPadding),
+      label.bottomAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -verticalPadding)
+    ])
+
     return headerView
+  }
+
+  override func tableView(_: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    let label = UILabel()
+    label.text = dataSet[section].headingTitle
+    label.font = UIFont.boldSystemFont(ofSize: fontSize * 1.1)
+    label.numberOfLines = 0
+    label.lineBreakMode = .byWordWrapping
+
+    let horizontalPadding: CGFloat = 32
+    let verticalPadding: CGFloat = 24
+
+    let constrainedWidth = tableView.bounds.width - horizontalPadding
+    let size = label.sizeThatFits(CGSize(width: constrainedWidth, height: CGFloat.greatestFiniteMagnitude))
+
+    return size.height + verticalPadding
   }
 }


### PR DESCRIPTION
This pull request addresses an issue where letters were being clipped in section headers, especially in right-to-left (RTL) languages like Arabic.

[x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

[x] I have tested my code with the xcodebuild 


The following changes were made:

Adjusted padding for section headers to ensure proper layout and prevent clipping.
Applied consistent styling for both LTR and RTL layouts.
Tested using xcodebuild and verified compliance with swiftlint --strict.
These changes improve the visual appearance and usability of the app for all supported languages.


- #518

Print Screen: 
![fixedbug](https://github.com/user-attachments/assets/d6949ae8-b536-4d40-958c-608d428f6ddd)



