### PR TITLE
Fix: Update tab bar titles on language change

### DIFF
--- a/Scribe/AboutTab/AboutViewController.swift
+++ b/Scribe/AboutTab/AboutViewController.swift
@@ -38,9 +38,7 @@ final class AboutViewController: BaseTableViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-
     showTipCardView()
-    title = NSLocalizedString("app.about.title", value: "About", comment: "")
 
     tableView.register(
       UINib(nibName: "AboutTableViewCell", bundle: nil),

--- a/Scribe/Base.lproj/AppScreen.storyboard
+++ b/Scribe/Base.lproj/AppScreen.storyboard
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -325,7 +326,7 @@
             </objects>
             <point key="canvasLocation" x="-2766" y="-100"/>
         </scene>
-        <!--Installation-->
+        <!--app.installation.title-->
         <scene sceneID="tne-QT-ifu">
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="InstallationVC" customModule="Scribe" customModuleProvider="target" sceneMemberID="viewController">
@@ -475,7 +476,7 @@
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="jrH-BQ-4ti" secondAttribute="trailing" constant="15" id="zOe-dD-pB6"/>
                         </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Installation" image="keyboard" catalog="system" id="HNz-5D-1T0"/>
+                    <tabBarItem key="tabBarItem" title="app.installation.title" image="keyboard" catalog="system" id="HNz-5D-1T0"/>
                     <connections>
                         <outlet property="appTextBackgroundPad" destination="Z6Q-k0-ggs" id="cdi-Kv-7aq"/>
                         <outlet property="appTextBackgroundPhone" destination="uV9-hG-bLi" id="s6y-0B-0qh"/>
@@ -498,11 +499,11 @@
             </objects>
             <point key="canvasLocation" x="-1831.2" y="-836.45320197044339"/>
         </scene>
-        <!--About-->
+        <!--app.about.title-->
         <scene sceneID="6lj-MX-SxG">
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="1wV-q3-U0F" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="About" image="info.circle" catalog="system" id="U3y-iM-H0G"/>
+                    <tabBarItem key="tabBarItem" tag="2" title="app.about.title" image="info.circle" catalog="system" id="U3y-iM-H0G"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" largeTitles="YES" id="Jq3-G5-4j6">
                         <rect key="frame" x="0.0" y="50" width="375" height="96"/>
@@ -519,11 +520,13 @@
             </objects>
             <point key="canvasLocation" x="-1831.2" y="640.64039408866995"/>
         </scene>
-        <!--Settings-->
+        <!--app.settings.title-->
         <scene sceneID="3xr-BX-tfK">
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Ffy-3M-wWx" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Settings" image="gearshape" catalog="system" id="JtD-kc-GDx"/>
+                    <tabBarItem key="tabBarItem" tag="1" title="app.settings.title" id="JtD-kc-GDx">
+                        <imageReference key="image" image="gearshape" catalog="system" variableValue="0.80000000000000004"/>
+                    </tabBarItem>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" largeTitles="YES" id="IHJ-rg-pcl">
                         <rect key="frame" x="0.0" y="50" width="375" height="96"/>

--- a/Scribe/InstallationTab/InstallationVC.swift
+++ b/Scribe/InstallationTab/InstallationVC.swift
@@ -92,7 +92,7 @@ class InstallationVC: UIViewController {
   /// Includes a call to checkDarkModeSetColors to set brand colors and a call to set the UI for the app screen.
   override func viewDidLoad() {
     super.viewDidLoad()
-    
+
     self.tabBarController?.viewControllers?[0].title = NSLocalizedString(
       "app.installation.title", value: "Installation", comment: ""
     )

--- a/Scribe/InstallationTab/InstallationVC.swift
+++ b/Scribe/InstallationTab/InstallationVC.swift
@@ -91,9 +91,9 @@ class InstallationVC: UIViewController {
 
   /// Includes a call to checkDarkModeSetColors to set brand colors and a call to set the UI for the app screen.
   override func viewDidLoad() {
-    
+
     title = NSLocalizedString("app.about.title", value: "Installation", comment: "")
-    
+
     super.viewDidLoad()
     setCurrentUI()
     showTipCardView()

--- a/Scribe/InstallationTab/InstallationVC.swift
+++ b/Scribe/InstallationTab/InstallationVC.swift
@@ -91,6 +91,9 @@ class InstallationVC: UIViewController {
 
   /// Includes a call to checkDarkModeSetColors to set brand colors and a call to set the UI for the app screen.
   override func viewDidLoad() {
+    
+    title = NSLocalizedString("app.about.title", value: "Installation", comment: "")
+    
     super.viewDidLoad()
     setCurrentUI()
     showTipCardView()

--- a/Scribe/InstallationTab/InstallationVC.swift
+++ b/Scribe/InstallationTab/InstallationVC.swift
@@ -91,10 +91,18 @@ class InstallationVC: UIViewController {
 
   /// Includes a call to checkDarkModeSetColors to set brand colors and a call to set the UI for the app screen.
   override func viewDidLoad() {
-
-    title = NSLocalizedString("app.about.title", value: "Installation", comment: "")
-
     super.viewDidLoad()
+    
+    self.tabBarController?.viewControllers?[0].title = NSLocalizedString(
+      "app.installation.title", value: "Installation", comment: ""
+    )
+    self.tabBarController?.viewControllers?[1].title = NSLocalizedString(
+      "app.settings.title", value: "Settings", comment: ""
+    )
+    self.tabBarController?.viewControllers?[2].title = NSLocalizedString(
+      "app.about.title", value: "About", comment: ""
+    )
+
     setCurrentUI()
     showTipCardView()
   }
@@ -240,7 +248,9 @@ class InstallationVC: UIViewController {
       fontSize = UIScreen.main.bounds.height / 50
     }
 
-    installationHeaderLabel.text = NSLocalizedString("app.installation.keyboard.title", value: "Keyboard installation", comment: "")
+    installationHeaderLabel.text = NSLocalizedString(
+      "app.installation.keyboard.title", value: "Keyboard installation", comment: ""
+    )
     installationHeaderLabel.font = UIFont.boldSystemFont(ofSize: fontSize * 1.1)
 
     setAppTextView()

--- a/Scribe/SettingsTab/SettingsViewController.swift
+++ b/Scribe/SettingsTab/SettingsViewController.swift
@@ -55,7 +55,6 @@ final class SettingsViewController: UIViewController {
     setHeaderHeight()
     showTipCardView()
 
-    title = NSLocalizedString("app.settings.title", value: "Settings", comment: "")
     navigationItem.backButtonTitle = title
 
     parentTable.register(


### PR DESCRIPTION
- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `xcodebuild` and `swiftlint --strict` commands as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-iOS/blob/main/CONTRIBUTING.md#testing)

---

### Description

Added logic to dynamically update the "Installation" tab bar item title when the language changes. The solution involved adding the following line to the InstallationViewController:

``` 
title = NSLocalizedString("app.installation.title", value: "Installation", comment: "")
```

![arabic](https://github.com/user-attachments/assets/66d22a78-931d-4737-907e-7aa5d6c73ba7)


### Observation
I forgot to remove the following code from SettingsViewController, which can be safely removed without any issues:

```
@objc func setText() {
    tabBarController?.tabBar.items?[0].title = NSLocalizedString("Installation", comment: "").uppercased()
}

override func viewWillDisappear(_ animated: Bool) {
    super.viewWillDisappear(animated)
    NotificationCenter.default.removeObserver(self)
}
```

These were added while I was working on solving the tab bar title issue, and they are no longer needed.


- #517 
