### PR TITLE
Switch case from conditional statement to determine keyboard width

### DIFF
--- a/Keyboards/KeyboardsBase/KeyboardKeys.swift
+++ b/Keyboards/KeyboardsBase/KeyboardKeys.swift
@@ -260,26 +260,25 @@ class KeyboardKey: UIButton {
         widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1).isActive = true
       case "#+=", "selectKeyboard":
         layer.setValue(true, forKey: "isSpecial")
-        widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.0).isActive = true
+        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarSpecialKeysWidth).isActive = true
       case "delete":
         layer.setValue(true, forKey: "isSpecial")
-        widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.65).isActive = true
-        
+        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarDeleteKeyWidth).isActive = true
       case SpecialKeys.capsLock:
         layer.setValue(true, forKey: "isSpecial")
-        widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.3).isActive = true
+        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarCapsLockKeyWidth).isActive = true
       case SpecialKeys.indent:
         layer.setValue(true, forKey: "isSpecial")
-        widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.0).isActive = true
+        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarIndentKeyWidth).isActive = true
       case "shift" where idx == 0:
         layer.setValue(true, forKey: "isSpecial")
-        widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.5).isActive = true
+        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarShiftKeyWidth).isActive = true
       case "shift" where idx > 0:
         layer.setValue(true, forKey: "isSpecial")
-        widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.5).isActive = true
+        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarRightShiftKeyWidth).isActive = true
       case "return":
         layer.setValue(true, forKey: "isSpecial")
-        widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.3).isActive = true
+        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarReturnKeyWidth).isActive = true
       case "123", ".?123", "return", "hideKeyboard":
         if DeviceType.isPad
             && key == "return"

--- a/Keyboards/KeyboardsBase/KeyboardKeys.swift
+++ b/Keyboards/KeyboardsBase/KeyboardKeys.swift
@@ -278,19 +278,17 @@ class KeyboardKey: UIButton {
         widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarRightShiftKeyWidth).isActive = true
       case "return":
         layer.setValue(true, forKey: "isSpecial")
-        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarReturnKeyWidth).isActive = true
-      case "123", ".?123", "return", "hideKeyboard":
         if DeviceType.isPad
-            && key == "return"
             && ((commandState != .translate && ["English", "Portuguese", "Italian"].contains(controllerLanguage)) ||
                 (commandState == .translate && ["en", "pt", "it"].contains(getControllerTranslateLangCode())))
             && row == 1 {
-          layer.setValue(true, forKey: "isSpecial")
           widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.5).isActive = true
         } else {
-          layer.setValue(true, forKey: "isSpecial")
-          widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1).isActive = true
+          widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarReturnKeyWidth).isActive = true
         }
+      case "123", ".?123", "hideKeyboard":
+        layer.setValue(true, forKey: "isSpecial")
+        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarSpecialKeysWidth).isActive = true
       default:
         if key != spaceBar && key != languageTextForSpaceBar {
           widthAnchor.constraint(equalToConstant: keyWidth).isActive = true

--- a/Keyboards/KeyboardsBase/KeyboardKeys.swift
+++ b/Keyboards/KeyboardsBase/KeyboardKeys.swift
@@ -254,81 +254,48 @@ class KeyboardKey: UIButton {
       scalarReturnKeyWidth = 1.3
       scalarShiftKeyWidth = 1.5
       scalarSpecialKeysWidth = 1.0
-
-      if ["ABC", "АБВ"].contains(key) {
+      switch key {
+      case "ABC", "АБВ":
         layer.setValue(true, forKey: "isSpecial")
         widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1).isActive = true
-      } else if ["#+=", "selectKeyboard"].contains(key) {
+      case "#+=", "selectKeyboard":
         layer.setValue(true, forKey: "isSpecial")
-        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarSpecialKeysWidth).isActive = true
-      } else if ["delete"].contains(key) {
+        widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.0).isActive = true
+      case "delete":
         layer.setValue(true, forKey: "isSpecial")
-        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarDeleteKeyWidth).isActive = true
-      } else if [SpecialKeys.capsLock].contains(key) {
+        widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.65).isActive = true
+        
+      case SpecialKeys.capsLock:
         layer.setValue(true, forKey: "isSpecial")
-        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarCapsLockKeyWidth).isActive = true
-      } else if [SpecialKeys.indent].contains(key) {
+        widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.3).isActive = true
+      case SpecialKeys.indent:
         layer.setValue(true, forKey: "isSpecial")
-        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarIndentKeyWidth).isActive = true
-      } else if ["shift"].contains(key) && idx == 0 {
+        widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.0).isActive = true
+      case "shift" where idx == 0:
         layer.setValue(true, forKey: "isSpecial")
-        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarShiftKeyWidth).isActive = true
-      } else if ["shift"].contains(key) && (idx > 0) {
+        widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.5).isActive = true
+      case "shift" where idx > 0:
         layer.setValue(true, forKey: "isSpecial")
-        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarRightShiftKeyWidth).isActive = true
-      } else if ["return"].contains(key) {
+        widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.5).isActive = true
+      case "return":
         layer.setValue(true, forKey: "isSpecial")
-        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarReturnKeyWidth).isActive = true
-      } else if ["123", ".?123", "return", "hideKeyboard"].contains(key) {
+        widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.3).isActive = true
+      case "123", ".?123", "return", "hideKeyboard":
         if DeviceType.isPad
-          && key == "return"
-          && (
-            (
-              commandState != .translate
-              && ["English", "Portuguese", "Italian"].contains(controllerLanguage)
-            ) || (
-              commandState == .translate
-              && ["en", "pt", "it"].contains(getControllerTranslateLangCode())
-            )
-          )
-          && row == 1 {
-          layer.setValue(true, forKey: "isSpecial")
-          widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarReturnKeyWidth).isActive = true
-        } else {
-          layer.setValue(true, forKey: "isSpecial")
-          widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1).isActive = true
-        }
-      } else if key != spaceBar && key != languageTextForSpaceBar {
-        widthAnchor.constraint(equalToConstant: keyWidth).isActive = true
-      }
-    } else {
-      if ["ABC", "АБВ"].contains(key) {
-        layer.setValue(true, forKey: "isSpecial")
-        widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1).isActive = true
-      } else if ["delete", "#+=", "shift", "selectKeyboard", SpecialKeys.indent, SpecialKeys.capsLock].contains(key) {
-        layer.setValue(true, forKey: "isSpecial")
-        widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1).isActive = true
-      } else if ["123", ".?123", "return", "hideKeyboard"].contains(key) {
-        if DeviceType.isPad
-          && key == "return"
-          && (
-            (
-              commandState != .translate
-              && ["English", "Portuguese", "Italian"].contains(controllerLanguage)
-            ) || (
-              commandState == .translate
-              && ["en", "pt", "it"].contains(getControllerTranslateLangCode())
-            )
-          )
-          && row == 1 {
+            && key == "return"
+            && ((commandState != .translate && ["English", "Portuguese", "Italian"].contains(controllerLanguage)) ||
+                (commandState == .translate && ["en", "pt", "it"].contains(getControllerTranslateLangCode())))
+            && row == 1 {
           layer.setValue(true, forKey: "isSpecial")
           widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.5).isActive = true
         } else {
           layer.setValue(true, forKey: "isSpecial")
           widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1).isActive = true
         }
-      } else if key != spaceBar && key != languageTextForSpaceBar {
-        widthAnchor.constraint(equalToConstant: keyWidth).isActive = true
+      default:
+        if key != spaceBar && key != languageTextForSpaceBar {
+          widthAnchor.constraint(equalToConstant: keyWidth).isActive = true
+        }
       }
     }
   }

--- a/Scribe/i18n/Scribe-i18n/Localizable.xcstrings
+++ b/Scribe/i18n/Scribe-i18n/Localizable.xcstrings
@@ -4393,7 +4393,6 @@
     },
     "app.installation.title" : {
       "comment" : "",
-      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `xcodebuild` and `swiftlint --strict` commands as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-iOS/blob/main/CONTRIBUTING.md#testing)

---

### Description
 Switch from conditional statements to switch and case statements to determine the keyboard width.

 ``` swift
switch key {
      case "ABC", "АБВ":
        layer.setValue(true, forKey: "isSpecial")
        widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1).isActive = true
     case "#+=", "selectKeyboard":
        layer.setValue(true, forKey: "isSpecial")
        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarSpecialKeysWidth).isActive = true
      case "delete":
        layer.setValue(true, forKey: "isSpecial")
        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarDeleteKeyWidth).isActive = true
      case SpecialKeys.capsLock:
        layer.setValue(true, forKey: "isSpecial")
        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarCapsLockKeyWidth).isActive = true
      case SpecialKeys.indent:
        layer.setValue(true, forKey: "isSpecial")
        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarIndentKeyWidth).isActive = true
      case "shift" where idx == 0:
        layer.setValue(true, forKey: "isSpecial")
        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarShiftKeyWidth).isActive = true
      case "shift" where idx > 0:
        layer.setValue(true, forKey: "isSpecial")
        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarRightShiftKeyWidth).isActive = true
      case "return":
        layer.setValue(true, forKey: "isSpecial")
        widthAnchor.constraint(equalToConstant: numSymKeyWidth * scalarReturnKeyWidth).isActive = true
      case "123", ".?123", "return", "hideKeyboard":
        if DeviceType.isPad
            && key == "return"
            && ((commandState != .translate && ["English", "Portuguese", "Italian"].contains(controllerLanguage)) ||
                (commandState == .translate && ["en", "pt", "it"].contains(getControllerTranslateLangCode())))
            && row == 1 {
          layer.setValue(true, forKey: "isSpecial")
          widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1.5).isActive = true
        } else {
          layer.setValue(true, forKey: "isSpecial")
          widthAnchor.constraint(equalToConstant: numSymKeyWidth * 1).isActive = true
        }
}
```

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #525 
