### PR TITLE
Add SPDX license identifier to all the .swift files.

### DIFF
--- a/Keyboards/InterfaceConstants.swift
+++ b/Keyboards/InterfaceConstants.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Constants for the Scribe keyboard interfaces.

--- a/Keyboards/InterfaceConstants.swift
+++ b/Keyboards/InterfaceConstants.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Constants for the Scribe keyboard interfaces.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 enum SpecialKeys {

--- a/Keyboards/KeyboardBuilder.swift
+++ b/Keyboards/KeyboardBuilder.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Building a keyboard layout using a builder pattern.

--- a/Keyboards/KeyboardBuilder.swift
+++ b/Keyboards/KeyboardBuilder.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Building a keyboard layout using a builder pattern.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import Foundation

--- a/Keyboards/KeyboardProvider.swift
+++ b/Keyboards/KeyboardProvider.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Define protocol for keyboard provider.

--- a/Keyboards/KeyboardProvider.swift
+++ b/Keyboards/KeyboardProvider.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Define protocol for keyboard provider.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import Foundation

--- a/Keyboards/KeyboardsBase/Extensions.swift
+++ b/Keyboards/KeyboardsBase/Extensions.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Extensions with helper functions for Scribe keyboards.

--- a/Keyboards/KeyboardsBase/Extensions.swift
+++ b/Keyboards/KeyboardsBase/Extensions.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Extensions with helper functions for Scribe keyboards.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/KeyboardsBase/InterfaceVariables.swift
+++ b/Keyboards/KeyboardsBase/InterfaceVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Variables associated with the base keyboard interface.

--- a/Keyboards/KeyboardsBase/InterfaceVariables.swift
+++ b/Keyboards/KeyboardsBase/InterfaceVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Variables associated with the base keyboard interface.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/KeyboardsBase/KeyAltChars.swift
+++ b/Keyboards/KeyboardsBase/KeyAltChars.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions and variables to create alternate key views.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/KeyboardsBase/KeyAltChars.swift
+++ b/Keyboards/KeyboardsBase/KeyAltChars.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Functions and variables to create alternate key views.

--- a/Keyboards/KeyboardsBase/KeyAnimation.swift
+++ b/Keyboards/KeyboardsBase/KeyAnimation.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions to animate key presses with pop up characters.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/KeyboardsBase/KeyAnimation.swift
+++ b/Keyboards/KeyboardsBase/KeyAnimation.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Functions to animate key presses with pop up characters.

--- a/Keyboards/KeyboardsBase/KeyboardKeys.swift
+++ b/Keyboards/KeyboardsBase/KeyboardKeys.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Classes and variables that define keys for Scribe keyboards.

--- a/Keyboards/KeyboardsBase/KeyboardKeys.swift
+++ b/Keyboards/KeyboardsBase/KeyboardKeys.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Classes and variables that define keys for Scribe keyboards.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/KeyboardsBase/KeyboardStyling.swift
+++ b/Keyboards/KeyboardsBase/KeyboardStyling.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Functions to style keyboard elements.

--- a/Keyboards/KeyboardsBase/KeyboardStyling.swift
+++ b/Keyboards/KeyboardsBase/KeyboardStyling.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions to style keyboard elements.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Classes for the parent keyboard view controller that language keyboards.

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Classes for the parent keyboard view controller that language keyboards.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import GRDB

--- a/Keyboards/KeyboardsBase/LanguageDBManager.swift
+++ b/Keyboards/KeyboardsBase/LanguageDBManager.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions for loading in data to the keyboards.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import Foundation

--- a/Keyboards/KeyboardsBase/LanguageDBManager.swift
+++ b/Keyboards/KeyboardsBase/LanguageDBManager.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Functions for loading in data to the keyboards.

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Annotate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Annotate.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions and elements that control word annotations.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Annotate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Annotate.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Functions and elements that control word annotations.

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Class defining the bar into which commands are typed.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandBar.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Class defining the bar into which commands are typed.

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Variables associated with Scribe commands.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import GRDB

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Variables associated with Scribe commands.

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Functions and elements that control the conjugation command.

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions and elements that control the conjugation command.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Plural.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Plural.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Functions that control the plural command.

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Plural.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Plural.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions that control the plural command.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/ScribeKey.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/ScribeKey.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Class defining the Scribe key that is used to access keyboard commands.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/ScribeKey.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/ScribeKey.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Class defining the Scribe key that is used to access keyboard commands.

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Functions that control the translate command.

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions that control the translate command.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/KeyboardsBase/ToolTip/Model/InformationToolTipData.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Model/InformationToolTipData.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Data used for tooltips.

--- a/Keyboards/KeyboardsBase/ToolTip/Model/InformationToolTipData.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Model/InformationToolTipData.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Data used for tooltips.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import Foundation

--- a/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewDatasource.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewDatasource.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Creates tooltips to be used in the ToolTipView.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import Foundation

--- a/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewDatasource.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewDatasource.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Creates tooltips to be used in the ToolTipView.

--- a/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewTheme.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewTheme.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Attributes for tooltips.

--- a/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewTheme.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Model/ToolTipViewTheme.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Attributes for tooltips.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/KeyboardsBase/ToolTip/Protocol/ToolTipViewDatasourceable.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Protocol/ToolTipViewDatasourceable.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Controls the ToolTipViewDatasourceable protocol.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import Foundation

--- a/Keyboards/KeyboardsBase/ToolTip/Protocol/ToolTipViewDatasourceable.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Protocol/ToolTipViewDatasourceable.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Controls the ToolTipViewDatasourceable protocol.

--- a/Keyboards/KeyboardsBase/ToolTip/Protocol/ToolTipViewUpdatable.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Protocol/ToolTipViewUpdatable.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Controls the ToolTipViewUpdatable protocol.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import Foundation

--- a/Keyboards/KeyboardsBase/ToolTip/Protocol/ToolTipViewUpdatable.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Protocol/ToolTipViewUpdatable.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Controls the ToolTipViewUpdatable protocol.

--- a/Keyboards/KeyboardsBase/ToolTip/Protocol/ViewThemeable.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Protocol/ViewThemeable.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Controls the ViewThemeable protocol.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/KeyboardsBase/ToolTip/Protocol/ViewThemeable.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/Protocol/ViewThemeable.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Controls the ViewThemeable protocol.

--- a/Keyboards/KeyboardsBase/ToolTip/ToolTipView.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/ToolTipView.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Shows the user an information view.

--- a/Keyboards/KeyboardsBase/ToolTip/ToolTipView.swift
+++ b/Keyboards/KeyboardsBase/ToolTip/ToolTipView.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Shows the user an information view.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/KeyboardsBase/Utilities.swift
+++ b/Keyboards/KeyboardsBase/Utilities.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Simple utility functions for data extraction and language management.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 /// Checks if an extra space is needed in the text field when generated text is inserted

--- a/Keyboards/KeyboardsBase/Utilities.swift
+++ b/Keyboards/KeyboardsBase/Utilities.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Simple utility functions for data extraction and language management.

--- a/Keyboards/LanguageKeyboards/Danish/DACommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Danish/DACommandVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Variables associated with commands for the Danish Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 func daSetConjugationLabels() {

--- a/Keyboards/LanguageKeyboards/Danish/DACommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Danish/DACommandVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Variables associated with commands for the Danish Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Danish/DAInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Danish/DAInterfaceVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Constants and functions to load the Danish Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/LanguageKeyboards/Danish/DAInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Danish/DAInterfaceVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Constants and functions to load the Danish Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Danish/DAKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Danish/DAKeyboardViewController.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Class for the Danish Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 class DAKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/Danish/DAKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Danish/DAKeyboardViewController.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Class for the Danish Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/English/ENCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/English/ENCommandVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Variables associated with commands for the English Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/English/ENCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/English/ENCommandVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Variables associated with commands for the English Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 func enSetConjugationLabels() {

--- a/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Constants and functions to load the English Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Constants and functions to load the English Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/LanguageKeyboards/English/ENKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/English/ENKeyboardViewController.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Class for the English Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/English/ENKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/English/ENKeyboardViewController.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Class for the English Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 class ENKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Constants and functions to load the AZERTY French Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Constants and functions to load the AZERTY French Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/French/FR-QWERTYInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FR-QWERTYInterfaceVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Constants and functions to load the QWERTY French Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 public enum FRQWERTYKeyboardConstants {

--- a/Keyboards/LanguageKeyboards/French/FR-QWERTYInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FR-QWERTYInterfaceVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Constants and functions to load the QWERTY French Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/French/FRCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FRCommandVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Variables associated with commands for the French Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 func frSetConjugationLabels() {

--- a/Keyboards/LanguageKeyboards/French/FRCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FRCommandVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Variables associated with commands for the French Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/French/FRKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/French/FRKeyboardViewController.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Class for the French Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/French/FRKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/French/FRKeyboardViewController.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Class for the French Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 class FRKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/German/DECommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DECommandVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Variables associated with commands for the German Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 func deSetConjugationLabels() {

--- a/Keyboards/LanguageKeyboards/German/DECommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DECommandVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Variables associated with commands for the German Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Constants and functions to load the German Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Constants and functions to load the German Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/German/DEKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/German/DEKeyboardViewController.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Class for the German Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 class DEKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/German/DEKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/German/DEKeyboardViewController.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Class for the German Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Hebrew/HECommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Hebrew/HECommandVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Variables associated with commands for the Hebrew Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 func heSetConjugationLabels() {

--- a/Keyboards/LanguageKeyboards/Hebrew/HECommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Hebrew/HECommandVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Variables associated with commands for the Hebrew Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Hebrew/HEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Hebrew/HEInterfaceVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Constants and functions to load the Hebrew Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Hebrew/HEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Hebrew/HEInterfaceVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Constants and functions to load the Hebrew Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/LanguageKeyboards/Hebrew/HEKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Hebrew/HEKeyboardViewController.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Class for the Hebrew Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Hebrew/HEKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Hebrew/HEKeyboardViewController.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Class for the Hebrew Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 class HEKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/Italian/ITCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITCommandVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Variables associated with commands for the Italian Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 func itSetConjugationLabels() {

--- a/Keyboards/LanguageKeyboards/Italian/ITCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITCommandVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Variables associated with commands for the Italian Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Constants and functions to load the Italian Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Constants and functions to load the Italian Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Italian/ITKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITKeyboardViewController.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Class for the Italian Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Italian/ITKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITKeyboardViewController.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Class for the Italian Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 class ITKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/Norwegian/NBCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Norwegian/NBCommandVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Variables associated with commands for the Norwegian Bokmål Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 func nbSetConjugationLabels() {

--- a/Keyboards/LanguageKeyboards/Norwegian/NBCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Norwegian/NBCommandVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Variables associated with commands for the Norwegian Bokmål Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Norwegian/NBInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Norwegian/NBInterfaceVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Constants and functions to load the Norwegian Bokmål Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/LanguageKeyboards/Norwegian/NBInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Norwegian/NBInterfaceVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Constants and functions to load the Norwegian Bokmål Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Norwegian/NBKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Norwegian/NBKeyboardViewController.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Class for the Norwegian Bokmål Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 class NBKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/Norwegian/NBKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Norwegian/NBKeyboardViewController.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Class for the Norwegian Bokmål Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Portuguese/PTCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTCommandVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Variables associated with commands for the Portuguese Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 func ptSetConjugationLabels() {

--- a/Keyboards/LanguageKeyboards/Portuguese/PTCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTCommandVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Variables associated with commands for the Portuguese Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Constants and functions to load the Portuguese Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Constants and functions to load the Portuguese Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/LanguageKeyboards/Portuguese/PTKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTKeyboardViewController.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Class for the Portuguese Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Portuguese/PTKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTKeyboardViewController.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Class for the Portuguese Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 class PTKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/Russian/RUCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUCommandVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Variables associated with commands for the Russian Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 func ruSetConjugationLabels() {

--- a/Keyboards/LanguageKeyboards/Russian/RUCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUCommandVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Variables associated with commands for the Russian Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Commands and functions to load the Russian Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Commands and functions to load the Russian Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Russian/RUKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUKeyboardViewController.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Class for the Russian Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 class RUKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/Russian/RUKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUKeyboardViewController.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Class for the Russian Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Spanish/ESCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESCommandVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Variables associated with commands for the Spanish Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 func esSetConjugationLabels() {

--- a/Keyboards/LanguageKeyboards/Spanish/ESCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESCommandVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Variables associated with commands for the Spanish Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Constants and functions to load the Spanish Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Constants and functions to load the Spanish Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/LanguageKeyboards/Spanish/ESKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESKeyboardViewController.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Class for the Spanish Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 class ESKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/Spanish/ESKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESKeyboardViewController.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Class for the Spanish Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Swedish/SVCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVCommandVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Variables associated with commands for the Swedish Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 func svSetConjugationLabels() {

--- a/Keyboards/LanguageKeyboards/Swedish/SVCommandVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVCommandVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Variables associated with commands for the Swedish Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Constants and functions to load the Swedish Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Constants and functions to load the Swedish Scribe keyboard.

--- a/Keyboards/LanguageKeyboards/Swedish/SVKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVKeyboardViewController.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Class for the Swedish Scribe keyboard.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 class SVKeyboardViewController: KeyboardViewController {}

--- a/Keyboards/LanguageKeyboards/Swedish/SVKeyboardViewController.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVKeyboardViewController.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Class for the Swedish Scribe keyboard.

--- a/Scribe/AboutTab/AboutTableData.swift
+++ b/Scribe/AboutTab/AboutTableData.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Controls data displayed in the About tab.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import Foundation

--- a/Scribe/AboutTab/AboutTableData.swift
+++ b/Scribe/AboutTab/AboutTableData.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Controls data displayed in the About tab.

--- a/Scribe/AboutTab/AboutViewController.swift
+++ b/Scribe/AboutTab/AboutViewController.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Functions for the About tab.

--- a/Scribe/AboutTab/AboutViewController.swift
+++ b/Scribe/AboutTab/AboutViewController.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions for the About tab.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import MessageUI

--- a/Scribe/AboutTab/InformationScreenVC.swift
+++ b/Scribe/AboutTab/InformationScreenVC.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Sets up information views in the About tab.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/AboutTab/InformationScreenVC.swift
+++ b/Scribe/AboutTab/InformationScreenVC.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Sets up information views in the About tab.

--- a/Scribe/AppDelegate.swift
+++ b/Scribe/AppDelegate.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Class of methods to manage Scribe's behaviors.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import CoreData

--- a/Scribe/AppDelegate.swift
+++ b/Scribe/AppDelegate.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Class of methods to manage Scribe's behaviors.

--- a/Scribe/AppExtensions.swift
+++ b/Scribe/AppExtensions.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Extensions for the Scribe app.

--- a/Scribe/AppExtensions.swift
+++ b/Scribe/AppExtensions.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Extensions for the Scribe app.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/AppStyling.swift
+++ b/Scribe/AppStyling.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions to style app elements.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/AppStyling.swift
+++ b/Scribe/AppStyling.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Functions to style app elements.

--- a/Scribe/AppTexts/AppTextStyling.swift
+++ b/Scribe/AppTexts/AppTextStyling.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Functions returning styled text elements for the app screen.

--- a/Scribe/AppTexts/AppTextStyling.swift
+++ b/Scribe/AppTexts/AppTextStyling.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions returning styled text elements for the app screen.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/AppTexts/InstallScreen.swift
+++ b/Scribe/AppTexts/InstallScreen.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * The app text for the Scribe app's keyboard installation screen.

--- a/Scribe/AppTexts/InstallScreen.swift
+++ b/Scribe/AppTexts/InstallScreen.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The app text for the Scribe app's keyboard installation screen.
- *
- * Copyright (C) 2023 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/AppTexts/ThirdPartyLicense.swift
+++ b/Scribe/AppTexts/ThirdPartyLicense.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Text displayed on the Third Party Licenses view.
- *
- * Copyright (C) 2023 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import SwiftUI

--- a/Scribe/AppTexts/ThirdPartyLicense.swift
+++ b/Scribe/AppTexts/ThirdPartyLicense.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Text displayed on the Third Party Licenses view.

--- a/Scribe/AppTexts/WikimediaAndScribe.swift
+++ b/Scribe/AppTexts/WikimediaAndScribe.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Text displayed on the English Wikimedia and Scribe view.

--- a/Scribe/AppTexts/WikimediaAndScribe.swift
+++ b/Scribe/AppTexts/WikimediaAndScribe.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Text displayed on the English Wikimedia and Scribe view.
- *
- * Copyright (C) 2023 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import SwiftUI

--- a/Scribe/AppUISymbols.swift
+++ b/Scribe/AppUISymbols.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions returning symbols for the app UI.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/AppUISymbols.swift
+++ b/Scribe/AppUISymbols.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Functions returning symbols for the app UI.

--- a/Scribe/Colors/ColorVariables.swift
+++ b/Scribe/Colors/ColorVariables.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Variables associated with coloration for Scribe keyboards.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/Colors/ColorVariables.swift
+++ b/Scribe/Colors/ColorVariables.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Variables associated with coloration for Scribe keyboards.

--- a/Scribe/Colors/ScribeColor.swift
+++ b/Scribe/Colors/ScribeColor.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Converts strings for colors into the corresponding color.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/Colors/ScribeColor.swift
+++ b/Scribe/Colors/ScribeColor.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Converts strings for colors into the corresponding color.

--- a/Scribe/Colors/UIColor+ScribeColors.swift
+++ b/Scribe/Colors/UIColor+ScribeColors.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Adds Scribe colors to the UIColor pool.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/Colors/UIColor+ScribeColors.swift
+++ b/Scribe/Colors/UIColor+ScribeColors.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Adds Scribe colors to the UIColor pool.

--- a/Scribe/Extensions/UIDeviceExtensions.swift
+++ b/Scribe/Extensions/UIDeviceExtensions.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Checks if the device has a home button or not via safe area checks.

--- a/Scribe/Extensions/UIDeviceExtensions.swift
+++ b/Scribe/Extensions/UIDeviceExtensions.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Checks if the device has a home button or not via safe area checks.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/Extensions/UIEdgeInsetsExtensions.swift
+++ b/Scribe/Extensions/UIEdgeInsetsExtensions.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Extensions for UIEdgeInsets.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/Extensions/UIEdgeInsetsExtensions.swift
+++ b/Scribe/Extensions/UIEdgeInsetsExtensions.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Extensions for UIEdgeInsets.

--- a/Scribe/InstallationTab/DownloadDataTable.swift
+++ b/Scribe/InstallationTab/DownloadDataTable.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The data table for the Download data screen of the Scribe app.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import Foundation

--- a/Scribe/InstallationTab/DownloadDataTable.swift
+++ b/Scribe/InstallationTab/DownloadDataTable.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * The data table for the Download data screen of the Scribe app.

--- a/Scribe/InstallationTab/DownloadDataVC.swift
+++ b/Scribe/InstallationTab/DownloadDataVC.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * The ViewController for the Download data screen of the Scribe app.

--- a/Scribe/InstallationTab/DownloadDataVC.swift
+++ b/Scribe/InstallationTab/DownloadDataVC.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The ViewController for the Download data screen of the Scribe app.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/InstallationTab/InstallationVC.swift
+++ b/Scribe/InstallationTab/InstallationVC.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * The ViewController for the Installation screen of the Scribe app.

--- a/Scribe/InstallationTab/InstallationVC.swift
+++ b/Scribe/InstallationTab/InstallationVC.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The ViewController for the Installation screen of the Scribe app.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/ParentTableCellModel.swift
+++ b/Scribe/ParentTableCellModel.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Contains structs that control how buttons in the About tab are built.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import Foundation

--- a/Scribe/ParentTableCellModel.swift
+++ b/Scribe/ParentTableCellModel.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Contains structs that control how buttons in the About tab are built.

--- a/Scribe/SettingsTab/SettingsTableData.swift
+++ b/Scribe/SettingsTab/SettingsTableData.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Controls data displayed in the Settings tab.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import Foundation

--- a/Scribe/SettingsTab/SettingsTableData.swift
+++ b/Scribe/SettingsTab/SettingsTableData.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Controls data displayed in the Settings tab.

--- a/Scribe/SettingsTab/SettingsViewController.swift
+++ b/Scribe/SettingsTab/SettingsViewController.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Functions for the Settings tab.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/SettingsTab/SettingsViewController.swift
+++ b/Scribe/SettingsTab/SettingsViewController.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Functions for the Settings tab.

--- a/Scribe/TipCard/TipCardView.swift
+++ b/Scribe/TipCard/TipCardView.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * The app tip views for the application tabs.

--- a/Scribe/TipCard/TipCardView.swift
+++ b/Scribe/TipCard/TipCardView.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * The app tip views for the application tabs.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import SwiftUI

--- a/Scribe/Views/BaseTableViewController.swift
+++ b/Scribe/Views/BaseTableViewController.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Base for table view in the Scribe app.

--- a/Scribe/Views/BaseTableViewController.swift
+++ b/Scribe/Views/BaseTableViewController.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Base for table view in the Scribe app.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import SwipeableTabBarController

--- a/Scribe/Views/Cells/InfoChildTableViewCell/InfoChildTableViewCell.swift
+++ b/Scribe/Views/Cells/InfoChildTableViewCell/InfoChildTableViewCell.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Class for a setting component with a heading, description and switch.

--- a/Scribe/Views/Cells/InfoChildTableViewCell/InfoChildTableViewCell.swift
+++ b/Scribe/Views/Cells/InfoChildTableViewCell/InfoChildTableViewCell.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Class for a setting component with a heading, description and switch.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/Views/Cells/RadioTableViewCell/RadioTableViewCell.swift
+++ b/Scribe/Views/Cells/RadioTableViewCell/RadioTableViewCell.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * DESCRIPTION_OF_THE_PURPOSE_OF_THE_FILE

--- a/Scribe/Views/Cells/RadioTableViewCell/RadioTableViewCell.swift
+++ b/Scribe/Views/Cells/RadioTableViewCell/RadioTableViewCell.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * DESCRIPTION_OF_THE_PURPOSE_OF_THE_FILE
- *
- * Copyright (C) 2023 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/Views/Cells/UITableViewCells/AboutTableViewCell.swift
+++ b/Scribe/Views/Cells/UITableViewCells/AboutTableViewCell.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Class for a button component with a label, icon and link icon.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/Views/Cells/UITableViewCells/AboutTableViewCell.swift
+++ b/Scribe/Views/Cells/UITableViewCells/AboutTableViewCell.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Class for a button component with a label, icon and link icon.

--- a/Scribe/Views/SelectionViewTemplateViewController.swift
+++ b/Scribe/Views/SelectionViewTemplateViewController.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * This file describes

--- a/Scribe/Views/SelectionViewTemplateViewController.swift
+++ b/Scribe/Views/SelectionViewTemplateViewController.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * This file describes
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Scribe/Views/TableViewTemplateViewController.swift
+++ b/Scribe/Views/TableViewTemplateViewController.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Controls the table views within the app.

--- a/Scribe/Views/TableViewTemplateViewController.swift
+++ b/Scribe/Views/TableViewTemplateViewController.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Controls the table views within the app.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import UIKit

--- a/Tests/Keyboards/KeyboardsBase/TestExtensions.swift
+++ b/Tests/Keyboards/KeyboardsBase/TestExtensions.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Tests for class extensions used in Scribe keyboards.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import Foundation

--- a/Tests/Keyboards/KeyboardsBase/TestExtensions.swift
+++ b/Tests/Keyboards/KeyboardsBase/TestExtensions.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Tests for class extensions used in Scribe keyboards.

--- a/Tests/Keyboards/KeyboardsBase/TestKeyboardStyling.swift
+++ b/Tests/Keyboards/KeyboardsBase/TestKeyboardStyling.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * Tests for keyboard styling used in Scribe keyboards.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import Foundation

--- a/Tests/Keyboards/KeyboardsBase/TestKeyboardStyling.swift
+++ b/Tests/Keyboards/KeyboardsBase/TestKeyboardStyling.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * Tests for keyboard styling used in Scribe keyboards.

--- a/Tests/Scribe/Views/BaseTableViewControllerTest.swift
+++ b/Tests/Scribe/Views/BaseTableViewControllerTest.swift
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
  * A base table view controller for testing Scribe.

--- a/Tests/Scribe/Views/BaseTableViewControllerTest.swift
+++ b/Tests/Scribe/Views/BaseTableViewControllerTest.swift
@@ -1,20 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 /**
  * A base table view controller for testing Scribe.
- *
- * Copyright (C) 2024 Scribe
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import Foundation


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `xcodebuild` and `swiftlint --strict` commands as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-iOS/blob/main/CONTRIBUTING.md#testing)

---

### Description

Replaced the existing license notice with the line: // SPDX-License-Identifier: AGPL-3.0-or-later to standardise license declarations across source files.

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #528 
