### PR TITLE
fix: Resolve table cell height constraints in Settings view

### DIFF
--- a/Scribe/SettingsTab/SettingsViewController.swift
+++ b/Scribe/SettingsTab/SettingsViewController.swift
@@ -206,6 +206,16 @@ extension SettingsViewController: UITableViewDelegate {
       tableView.deselectRow(at: selectedIndexPath, animated: false)
     }
   }
+  
+  func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+      let section = tableData[indexPath.section]
+      let setting = section.section[indexPath.row]
+      
+      
+      let hasDescription = setting.shortDescription != nil
+      return hasDescription ? 80.0 : 48.0 
+    }
+
 
   func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
     let headerView: UIView

--- a/Scribe/Views/Cells/InfoChildTableViewCell/InfoChildTableViewCell.swift
+++ b/Scribe/Views/Cells/InfoChildTableViewCell/InfoChildTableViewCell.swift
@@ -91,12 +91,11 @@ final class InfoChildTableViewCell: UITableViewCell {
     titleLabel.text = section.sectionTitle
 
     if let shortDescription = section.shortDescription {
-      descriptionLabel.text = shortDescription
-
-      contentView.addSubview(descriptionLabel)
+        descriptionLabel.text = shortDescription
+        descriptionLabel.isHidden = false
     } else {
-      descriptionLabel.text = nil
-      descriptionLabel.removeFromSuperview()
+        descriptionLabel.text = nil
+        descriptionLabel.isHidden = true
     }
 
     if section.hasToggle {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `xcodebuild` and `swiftlint --strict` commands as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-iOS/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Add proper height calculation for InfoChildTableViewCell based on content type. This prevents Auto Layout warnings about ambiguous height constraints when cells contain description text. I have made it not remove the description view from the hierarchy and rather adjusted the height of the cell based on whether description was present or not. 

### Related issue

<!--- Scribe-iOS prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #530 
