### PR TITLE
Added period to keyboard for any browser input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
   - The keyboard will switch to the appropriate source keyboard during translation and results will be returned from that language.
 - Scribe commands can now be triggered directly on a selected word by pressing the Scribe key and then choosing which command to use ([#141](https://github.com/scribe-org/Scribe-iOS/issues/141)).
 - Users can toggle whether the double space period shortcut is enabled on a per keyboard basis ([#479](https://github.com/scribe-org/Scribe-iOS/issues/479)).
+- A period is added to the letter keys if the keyboard is being used in a search bar ([#447](https://github.com/scribe-org/Scribe-iOS/issues/447)).
 
 ### 🎨 Design Changes
 

--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -2231,11 +2231,13 @@ class KeyboardViewController: UIInputViewController {
     if let userDefaults = UserDefaults(suiteName: "group.be.scri.userDefaultsContainer") {
       let dictionaryKey = langCode + "CommaAndPeriod"
       let letterKeysHaveCommaPeriod = userDefaults.bool(forKey: dictionaryKey)
+      let spaceIndex = letterKeys[3].firstIndex(where: { $0 == "space" })
 
       if letterKeysHaveCommaPeriod {
-        let spaceIndex = letterKeys[3].firstIndex(where: { $0 == "space" })
         letterKeys[3].insert(",", at: spaceIndex!)
         letterKeys[3].insert(".", at: spaceIndex! + 2)
+      } else if proxy.keyboardType == .webSearch {
+        letterKeys[3].insert(".", at: spaceIndex! + 1)
       }
     }
   }


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `xcodebuild` and `swiftlint --strict` commands as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-iOS/blob/main/CONTRIBUTING.md#testing)

---

### Description

Made the period key visible on all keyboards when opened by a browser search engine, regardless of layout settings. 

Tested for functionality on iPad (iOS 17.5) and iPhone (iOS 18.5) simulators using the following test cases. iPad functionality is not affected by this change.
- Browser search bar text input with "comma and period" option selected
- Browser search bar text input with "comma and period" option deselected
- Non-browser text input with "comma and period" option selected
- Non-browser text input with "comma and period" option deselected

### Related issue

- #447 
