### PR TITLE
fix url for simulator documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ pre-commit install
 
 5. In order to run Scribe on an emulator:
 
-   - Read the [documentation from Apple](https://developer.apple.com/documentation/xcode/running-your-app-in-the-simulator-or-on-a-device) if need be
+   - Read the [documentation from Apple](https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device) if need be
    - In the top bar select Scribe as the scheme
    - If you're debugging you'll need to select the keyboard you're testing as the scheme (see the [note on debugging](#note-on-debugging) below)
    - Select a device to run the app on


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [] I have tested my code with the `xcodebuild` and `swiftlint --strict` commands as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-iOS/blob/main/CONTRIBUTING.md#testing)

---

### Description
Updating the url on how to run app in simulator cause the old one doesn't work.
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue


- #542 
