### PR TITLE
fix: switch translation message from Wikidata to Wiktionary

### DIFF
--- a/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/English/ENInterfaceVariables.swift
@@ -207,7 +207,7 @@ func setENKeyboardLayout() {
   currencySymbol = "$"
   currencySymbolAlternates = dollarAlternateKeys
   spaceBar = "space"
-  invalidCommandMsg = "Not in Wikidata"
+  invalidCommandMsg = "Not in Wiktionary"
   baseAutosuggestions = ["I", "I'm", "we"]
   numericAutosuggestions = ["is", "to", "and"]
   verbsAfterPronounsArray = ["have", "be", "can"]

--- a/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/French/FR-AZERTYInterfaceVariables.swift
@@ -204,7 +204,7 @@ func setFRKeyboardLayout() {
   currencySymbolAlternates = euroAlternateKeys
   spaceBar = "espace"
   language = "Français"
-  invalidCommandMsg = "Pas dans Wikidata"
+  invalidCommandMsg = "Pas dans Wiktionary"
   baseAutosuggestions = ["je", "il", "le"]
   numericAutosuggestions = ["je", "que", "c’est"]
   verbsAfterPronounsArray = ["être", "avoir", "ne"]

--- a/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/German/DEInterfaceVariables.swift
@@ -263,7 +263,7 @@ func setDEKeyboardLayout() {
   currencySymbolAlternates = euroAlternateKeys
   spaceBar = "Leerzeichen"
   language = "Deutsch"
-  invalidCommandMsg = "Nicht in Wikidata"
+  invalidCommandMsg = "Nicht in Wiktionary"
   baseAutosuggestions = ["ich", "die", "das"]
   numericAutosuggestions = ["Prozent", "Milionen", "Meter"]
   verbsAfterPronounsArray = ["haben", "sein", "können"]

--- a/Keyboards/LanguageKeyboards/Indonesian/IDInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Indonesian/IDInterfaceVariables.swift
@@ -191,7 +191,7 @@ func setIDKeyboardLayout() {
   currencySymbol = "$"
   currencySymbolAlternates = dollarAlternateKeys
   spaceBar = "spasi"
-  invalidCommandMsg = "Tidak ada di Wikidata"
+  invalidCommandMsg = "Tidak ada di Wiktionary"
   baseAutosuggestions = ["aku", "saya", "itu"]
   numericAutosuggestions = ["adalah", "untuk", "dan"]
   verbsAfterPronounsArray = ["sudah", "sedang", "bisa"]

--- a/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Italian/ITInterfaceVariables.swift
@@ -204,7 +204,7 @@ func setITKeyboardLayout() {
   currencySymbolAlternates = euroAlternateKeys
   spaceBar = "spazio"
   language = "Italiano"
-  invalidCommandMsg = "Non in Wikidata"
+  invalidCommandMsg = "Non in Wiktionary"
   baseAutosuggestions = ["ho", "non", "ma"]
   numericAutosuggestions = ["utenti", "anni", "e"]
 

--- a/Keyboards/LanguageKeyboards/Norwegian/NBInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Norwegian/NBInterfaceVariables.swift
@@ -208,7 +208,7 @@ func setNBKeyboardLayout() {
   currencySymbolAlternates = kronaAlternateKeys
   spaceBar = "mellomrom"
   language = "Norsk"
-  invalidCommandMsg = "Ikke i Wikidata"
+  invalidCommandMsg = "Ikke i Wiktionary"
   baseAutosuggestions = ["jeg", "det", "er"]
   numericAutosuggestions = ["prosent", "millioner", "meter"]
   verbsAfterPronounsArray = ["har", "være", "kan"]

--- a/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Portuguese/PTInterfaceVariables.swift
@@ -202,7 +202,7 @@ func setPTKeyboardLayout() {
   currencySymbolAlternates = dollarAlternateKeys
   spaceBar = "espaço"
   language = "Português"
-  invalidCommandMsg = "Não está no Wikidata"
+  invalidCommandMsg = "Não está no Wiktionary"
   baseAutosuggestions = ["o", "a", "eu"]
   numericAutosuggestions = ["de", "que", "a"]
 

--- a/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Russian/RUInterfaceVariables.swift
@@ -192,7 +192,7 @@ func setRUKeyboardLayout() {
   currencySymbolAlternates = roubleAlternateKeys
   spaceBar = "Пробел"
   language = "Pусский"
-  invalidCommandMsg = "Нет в Викиданных"
+  invalidCommandMsg = "Нет в Викисловаре"
   baseAutosuggestions = ["я", "а", "в"]
   numericAutosuggestions = ["в", "и", "я"]
 

--- a/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Spanish/ESInterfaceVariables.swift
@@ -257,7 +257,7 @@ func setESKeyboardLayout() {
   currencySymbolAlternates = dollarAlternateKeys
   spaceBar = "espacio"
   language = "Español"
-  invalidCommandMsg = "No en Wikidata"
+  invalidCommandMsg = "No en Wiktionary"
   baseAutosuggestions = ["el", "la", "no"]
   numericAutosuggestions = ["que", "de", "en"]
   verbsAfterPronounsArray = ["ser", "REFLEXIVE_PRONOUN", "no"]

--- a/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
+++ b/Keyboards/LanguageKeyboards/Swedish/SVInterfaceVariables.swift
@@ -268,7 +268,7 @@ func setSVKeyboardLayout() {
   currencySymbolAlternates = kronaAlternateKeys
   spaceBar = "mellanslag"
   language = "Svenska"
-  invalidCommandMsg = "Inte i Wikidata"
+  invalidCommandMsg = "Inte i Wiktionary"
   baseAutosuggestions = ["jag", "det", "men"]
   numericAutosuggestions = ["jag", "det", "och"]
 

--- a/Tests/Keyboards/KeyboardsBase/TestKeyboardStyling.swift
+++ b/Tests/Keyboards/KeyboardsBase/TestKeyboardStyling.swift
@@ -33,10 +33,10 @@ class KeyboardStylingTest: XCTestCase {
 
   func testStyleBtnWithInvalidCommandMsg() {
     let button = UIButton(type: .system)
-    let title = "Not in Wikidata"
+    let title = "Not in Wiktionary"
     let radius = 4.0
 
-    invalidCommandMsg = "Not in Wikidata"
+    invalidCommandMsg = "Not in Wiktionary"
     styleBtn(btn: button, title: title, radius: radius)
 
     XCTAssertEqual(button.configuration?.baseForegroundColor, UITraitCollection.current.userInterfaceStyle == .light ? specialKeyColor : keyColor)


### PR DESCRIPTION
## Summary

- Updates `invalidCommandMsg` from "Not in Wikidata" to "Not in Wiktionary" across all 10 language keyboards (English, German, French, Spanish, Italian, Portuguese, Swedish, Norwegian, Indonesian, Russian)
- Updates the corresponding test in `TestKeyboardStyling.swift`
- Russian uses the localized name "Викисловарь" (Wiktionary) replacing "Викиданных" (Wikidata)
- Hebrew's generic message ("אין מידע" / "No data") was left unchanged as it doesn't reference Wikidata

Closes #597

## Test plan

- [x] Verified all `invalidCommandMsg` assignments updated via grep
- [x] Test file updated to match new string
- [ ] @0xLeif review

🤖 Generated with [Claude Code](https://claude.com/claude-code)