### PR TITLE
Show closest word suggestion on invalid Translate or Conjugate

### DIFF
--- a/Keyboards/KeyboardsBase/KeyboardViewController.swift
+++ b/Keyboards/KeyboardsBase/KeyboardViewController.swift
@@ -2069,7 +2069,11 @@ class KeyboardViewController: UIInputViewController {
                 autoCapAtStartOfProxy()
 
                 if commandState == .invalid {
-                    commandBar.text = commandPromptSpacing + invalidCommandMsgWikidata
+                    if !didYouMeanWord.isEmpty {
+                        commandBar.text = commandPromptSpacing + "Did you mean: " + didYouMeanWord + "?"
+                    } else {
+                        commandBar.text = commandPromptSpacing + invalidCommandMsgWikidata
+                    }
                     commandBar.isShowingInfoButton = true
                 } else {
                     commandBar.isShowingInfoButton = false
@@ -2078,6 +2082,7 @@ class KeyboardViewController: UIInputViewController {
                     }
                 }
                 commandBar.textColor = keyCharColor
+                didYouMeanWord = ""
                 return
             } else if [.translate, .plural].contains(commandState) { // functional commands above
                 autoActionState = .suggest
@@ -2096,9 +2101,14 @@ class KeyboardViewController: UIInputViewController {
                     loadKeys()
                     proxy.insertText(selectedText)
                     autoCapAtStartOfProxy()
-                    commandBar.text = commandPromptSpacing + invalidCommandMsgWiktionary
+                    if !didYouMeanWord.isEmpty {
+                        commandBar.text = commandPromptSpacing + "Did you mean: " + didYouMeanWord + "?"
+                    } else {
+                        commandBar.text = commandPromptSpacing + invalidCommandMsgWiktionary
+                    }
                     commandBar.isShowingInfoButton = true
                     commandBar.textColor = keyCharColor
+                    didYouMeanWord = ""
                     return
                 } else { // functional commands above
                     autoActionState = .suggest
@@ -2130,9 +2140,14 @@ class KeyboardViewController: UIInputViewController {
                     loadKeys()
                     proxy.insertText(selectedText)
                     autoCapAtStartOfProxy()
-                    commandBar.text = commandPromptSpacing + invalidCommandMsgWikidata
+                    if !didYouMeanWord.isEmpty {
+                        commandBar.text = commandPromptSpacing + "Did you mean: " + didYouMeanWord + "?"
+                    } else {
+                        commandBar.text = commandPromptSpacing + invalidCommandMsgWikidata
+                    }
                     commandBar.isShowingInfoButton = true
                     commandBar.textColor = keyCharColor
+                    didYouMeanWord = ""
                     return
                 }
             } else {

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/CommandVariables.swift
@@ -49,6 +49,7 @@ var commandPromptSpacing = ""
 var inputWordIsCapitalized = false
 var wordToReturn = ""
 var potentialWordsToReturn = [String]()
+var didYouMeanWord = ""
 
 var invalidCommandMsgWikidata = ""
 var invalidCommandTextWikidata1 = ""

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Conjugate.swift
@@ -41,5 +41,11 @@ func isVerbInConjugationTable(queriedVerbToConjugate: String) -> Bool {
     let columnName = (controllerLanguage == "Swedish") ? "verb" : "infinitive"
     let results = LanguageDBManager.shared.queryVerb(of: verbToConjugate, with: [columnName])
 
-    return !results.isEmpty && !results[0].isEmpty
+    let verbExists = !results.isEmpty && !results[0].isEmpty
+    if !verbExists {
+        let suggestions = LanguageDBManager.shared.queryAutocompletions(word: verbToConjugate)
+        didYouMeanWord = suggestions.first ?? ""
+    }
+
+    return verbExists
 }

--- a/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
+++ b/Keyboards/KeyboardsBase/ScribeFunctionality/Translate.swift
@@ -42,6 +42,8 @@ func queryWordToTranslate(queriedWordToTranslate: String) {
         wordToReturn = LanguageDBManager.translations.queryTranslation(of: wordToTranslate)[0]
         guard !wordToReturn.isEmpty
         else {
+            let suggestions = LanguageDBManager.shared.queryAutocompletions(word: wordToTranslate.lowercased())
+            didYouMeanWord = suggestions.first ?? ""
             commandState = .invalid
             return
         }


### PR DESCRIPTION
## Summary

- When a Translate or Conjugate command returns invalid, the command bar now shows **"Did you mean: X?"** using the closest match from the existing `queryAutocompletions` infrastructure
- Falls back to the existing "Not in Wikidata/Wiktionary" error message when no suggestion is available
- Covers all three invalid paths: typed command via return key, and selected-text Translate/Conjugate via the Scribe key menu

## Changes

| File | Change |
|---|---|
| `CommandVariables.swift` | Added `didYouMeanWord` variable to hold the suggestion |
| `Translate.swift` | Query autocompletions for closest match when translation fails |
| `Conjugate.swift` | Query autocompletions for closest match when verb not found |
| `KeyboardViewController.swift` | Display "Did you mean: X?" in command bar when suggestion exists |

## Notes

- No new DB queries needed — reuses `LanguageDBManager.shared.queryAutocompletions(word:)` 
- Purely additive — no existing logic removed
- "Did you mean" strings are hard-coded for now pending i18n entry

Fixes #640

## Test plan

- [ ] Type an invalid/misspelled word in Translate mode → verify "Did you mean: X?" appears
- [ ] Type an invalid/misspelled verb in Conjugate mode → verify "Did you mean: X?" appears  
- [ ] Select text and use Translate with an invalid word → verify suggestion appears
- [ ] Select text and use Conjugate with an invalid verb → verify suggestion appears
- [ ] Enter complete nonsense with no close matches → verify fallback to "Not in Wikidata/Wiktionary"
- [ ] Verify Plural command still shows original error (not affected)