### PR TITLE
fix(ci): update simulator destination to iPhone 17

### DIFF
--- a/.github/workflows/ci_test.yaml
+++ b/.github/workflows/ci_test.yaml
@@ -38,11 +38,11 @@ jobs:
 
       - name: Build
         run: |
-          xcodebuild -scheme Scribe -derivedDataPath Build/ -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' clean build | xcpretty
+          xcodebuild -scheme Scribe -derivedDataPath Build/ -destination 'platform=iOS Simulator,name=iPhone 17' clean build | xcpretty
 
       - name: Test and Generate Coverage
         run: |
-          xcodebuild -scheme Scribe -derivedDataPath Build/ -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' test -enableCodeCoverage YES CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
+          xcodebuild -scheme Scribe -derivedDataPath Build/ -destination 'platform=iOS Simulator,name=iPhone 17' test -enableCodeCoverage YES CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
           xcrun xccov view --report $(find ./Build/Logs/Test -name '*.xcresult') --json > code_coverage.json
 
       - name: Parse Coverage and Print to Terminal


### PR DESCRIPTION
Closes #656

## Summary
Fixes the CI test failure where the runner was unable to locate the `iPhone 16` (`OS: 18.5`) simulator destination.

## Changes
- Updated `.github/workflows/ci_test.yaml` to target `iPhone 17` (omitting the exact `OS` version). Omitting the `OS` parameter allows `xcodebuild` to automatically resolve to the latest available iOS simulator of that model, making it much more robust against runner updates.

## Verification
- Verified locally that tests build and pass successfully using this destination specifier.