### PR TITLE
fix(settings): resolve iPad menu text cropping and layout (#659)

### DIFF
--- a/Scribe/AboutTab/AboutViewController.swift
+++ b/Scribe/AboutTab/AboutViewController.swift
@@ -88,7 +88,13 @@ extension AboutViewController {
         let setting = section.section[indexPath.row]
 
         let hasDescription = setting.shortDescription != nil
-        return hasDescription ? 80.0 : 48.0
+        let userDefaults = UserDefaults(suiteName: "group.be.scri.userDefaultsContainer")
+        let fontScale: CGFloat = userDefaults?.bool(forKey: "increaseTextSize") == true ? 1.25 : 1.0
+
+        if DeviceType.isPad {
+            return (hasDescription ? 110.0 : 72.0) * fontScale
+        }
+        return (hasDescription ? 80.0 : 48.0) * fontScale
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Scribe/Info.plist
+++ b/Scribe/Info.plist
@@ -28,6 +28,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>

--- a/Scribe/SettingsTab/SettingsViewController.swift
+++ b/Scribe/SettingsTab/SettingsViewController.swift
@@ -270,26 +270,46 @@ extension SettingsViewController: UITableViewDelegate {
         let setting = section.section[indexPath.row]
 
         let hasDescription = setting.shortDescription != nil
-        return hasDescription ? 80.0 : 48.0
+        let userDefaults = UserDefaults(suiteName: "group.be.scri.userDefaultsContainer")
+        let fontScale: CGFloat = userDefaults?.bool(forKey: "increaseTextSize") == true ? 1.25 : 1.0
+
+        if DeviceType.isPad {
+            return (hasDescription ? 110.0 : 66.0) * fontScale
+        }
+        return (hasDescription ? 80.0 : 48.0) * fontScale
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        let label = UILabel()
+        label.text = tableData[section].headingTitle
+        label.font = UIFont.boldSystemFont(ofSize: fontSize * 1.1)
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+
+        let horizontalPadding: CGFloat = 32
+        let verticalPadding: CGFloat = 16
+
+        let constrainedWidth = parentTable.bounds.width - horizontalPadding
+        let size = label.sizeThatFits(
+            CGSize(width: constrainedWidth, height: CGFloat.greatestFiniteMagnitude)
+        )
+
+        let minHeaderHeight: CGFloat = DeviceType.isPad ? 42.0 : 32.0
+        return max(size.height + verticalPadding, minHeaderHeight)
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let headerView: UIView
-
-        if let reusableHeaderView = tableView.headerView(forSection: section) {
-            headerView = reusableHeaderView
-        } else {
-            headerView = UIView(
-                frame: CGRect(x: 0, y: 0, width: parentTable.bounds.width, height: 32)
-            )
-        }
+        let headerHeight = self.tableView(tableView, heightForHeaderInSection: section)
+        let headerView = UIView(
+            frame: CGRect(x: 0, y: 0, width: parentTable.bounds.width, height: headerHeight)
+        )
 
         let label = UILabel(
             frame: CGRect(
                 x: preferredLanguage.prefix(2) == "ar" ? -1 * headerView.bounds.width / 10 : 0,
                 y: 0,
                 width: headerView.bounds.width,
-                height: 32
+                height: headerHeight
             )
         )
 

--- a/Scribe/Views/Cells/InfoChildTableViewCell/InfoChildTableViewCell.swift
+++ b/Scribe/Views/Cells/InfoChildTableViewCell/InfoChildTableViewCell.swift
@@ -99,6 +99,7 @@ final class InfoChildTableViewCell: UITableViewCell {
         } else {
             descriptionLabel.text = nil
             descriptionLabel.isHidden = true
+            descriptionLabel.removeFromSuperview()
         }
 
         if section.hasToggle {

--- a/Scribe/Views/SelectionViewTemplateViewController.swift
+++ b/Scribe/Views/SelectionViewTemplateViewController.swift
@@ -74,6 +74,14 @@ extension SelectionViewTemplateViewController {
         return cell
     }
 
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        let fontScale: CGFloat = userDefaults.bool(forKey: "increaseTextSize") ? 1.25 : 1.0
+        if DeviceType.isPad {
+            return 66.0 * fontScale
+        }
+        return 48.0 * fontScale
+    }
+
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let cell = tableView.cellForRow(at: indexPath) as! RadioTableViewCell
         let oldLang = userDefaults.string(forKey: langCode + "TranslateLanguage") ?? "en"

--- a/Scribe/Views/TableViewTemplateViewController.swift
+++ b/Scribe/Views/TableViewTemplateViewController.swift
@@ -119,10 +119,12 @@ extension TableViewTemplateViewController {
         let section = dataSet[indexPath.section]
         let setting = section.section[indexPath.row]
 
+        let fontScale: CGFloat = userDefaults.bool(forKey: "increaseTextSize") ? 1.25 : 1.0
+
         // If there's no description, return a fixed small height.
         guard let description = setting.shortDescription
         else {
-            return 54.0
+            return (DeviceType.isPad ? 66.0 : 54.0) * fontScale
         }
 
         // Calculate available width for text.
@@ -156,7 +158,8 @@ extension TableViewTemplateViewController {
         ).height
 
         // Return total height: title + description + padding buffer.
-        return ceil(titleHeight + descHeight + 52)
+        let padding: CGFloat = DeviceType.isPad ? 64.0 : 52.0
+        return ceil((titleHeight + descHeight + padding) * fontScale)
     }
 
     override func tableView(_: UITableView, didSelectRowAt indexPath: IndexPath) {


### PR DESCRIPTION
## Description
Fixes #659 where settings menu items (such as the installed keyboard list) displayed vertically cropped/squeezed text on iPad models (e.g. iPad Air 11-inch).

### Screenshots
<img width="400" alt="iPad Air 11-inch Settings Menu Fix" src="https://github.com/user-attachments/assets/600342ff-990b-4e00-b6fa-c056596ac130" />

---

### Root Causes
1. **Unremoved Hidden Constraints**: When `shortDescription` was `nil` (e.g. for installed keyboard rows), `descriptionLabel` was hidden (`isHidden = true`) without being removed from the superview. Its Auto Layout constraints (`TitleLabelPad.bottom + 8` → `descriptionLabel.top` and `descriptionLabel.bottom` → `contentView.bottom - 16`) remained active, forcing a minimum cell height of ~99pt.
2. **Fixed iPhone Row Heights on iPad**: Table view controllers returned fixed row heights (`48.0pt`) for cells without descriptions. Forcing `TitleLabelPad` inside 48pt crushed the label height down to ~8–12pt, causing severe top/bottom text cropping.
3. **Stage Manager / Full-Screen Presentation**: Modern iPadOS models run non-fullscreen apps in Stage Manager window frames by default unless full-screen presentation is configured.

---

### Key Changes Made

- **`InfoChildTableViewCell.swift`**:
  - Added `descriptionLabel.removeFromSuperview()` when `shortDescription == nil`. This breaks the active bottom constraint chain when no description is present, allowing single-line iPad cells to render at 66pt cleanly without vertical squishing.
- **`SettingsViewController.swift`**:
  - Updated `tableView(_:heightForRowAt:)` to return device-appropriate row heights (`66.0pt` base / `110.0pt` with description on iPad, `48.0pt` / `80.0pt` on iPhone) with dynamic scaling support for the "Increase app text size" setting.
  - Implemented dynamic section header height calculation (`heightForHeaderInSection`) so section headers do not clip on iPad.
- **`AboutViewController.swift`**:
  - Updated `tableView(_:heightForRowAt:)` for iPad layout (`72.0pt` base / `110.0pt` with description) and text size scaling.
- **`TableViewTemplateViewController.swift`**:
  - Updated `tableView(_:heightForRowAt:)` for iPad layout (`66.0pt` base row height) and font scale support.
- **`SelectionViewTemplateViewController.swift`**:
  - Implemented `tableView(_:heightForRowAt:)` returning `66.0pt` for iPad `RadioTableViewCell` items with text size scaling support.
- **`Info.plist`**:
  - Added `<key>UIRequiresFullScreen</key><true/>` so the app requests full-screen presentation mode on iPad.

---

CC: @andrewtavis @henrikth93
